### PR TITLE
🟣 [UI | 8 pontos] Tela de Listagem de Denúncias com Filtros e Paginação

### DIFF
--- a/cidade_integra/lib/models/report.dart
+++ b/cidade_integra/lib/models/report.dart
@@ -1,0 +1,146 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+enum ReportStatus { pending, review, resolved, rejected }
+
+enum ReportCategory { buracos, iluminacao, lixo, vazamentos, areasVerdes, outros }
+
+class ReportLocation {
+  final double? latitude;
+  final double? longitude;
+  final String address;
+  final String? postalCode;
+
+  const ReportLocation({
+    this.latitude,
+    this.longitude,
+    this.address = '',
+    this.postalCode,
+  });
+
+  factory ReportLocation.fromMap(Map<String, dynamic> map) {
+    return ReportLocation(
+      latitude: (map['latitude'] as num?)?.toDouble(),
+      longitude: (map['longitude'] as num?)?.toDouble(),
+      address: map['address'] ?? '',
+      postalCode: map['postalCode'],
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'latitude': latitude,
+      'longitude': longitude,
+      'address': address,
+      'postalCode': postalCode,
+    };
+  }
+}
+
+class Report {
+  final String id;
+  final String title;
+  final String description;
+  final ReportCategory category;
+  final bool isAnonymous;
+  final String? userId;
+  final ReportLocation location;
+  final List<String> imageUrls;
+  final ReportStatus status;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final DateTime? resolvedAt;
+
+  const Report({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.category,
+    required this.isAnonymous,
+    this.userId,
+    required this.location,
+    this.imageUrls = const [],
+    required this.status,
+    required this.createdAt,
+    required this.updatedAt,
+    this.resolvedAt,
+  });
+
+  factory Report.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return Report(
+      id: doc.id,
+      title: data['title'] ?? '',
+      description: data['description'] ?? '',
+      category: ReportCategory.values.firstWhere(
+        (c) => c.name == data['category'],
+        orElse: () => ReportCategory.outros,
+      ),
+      isAnonymous: data['isAnonymous'] ?? false,
+      userId: data['userId'],
+      location: ReportLocation.fromMap(
+        data['location'] is Map<String, dynamic>
+            ? data['location']
+            : <String, dynamic>{},
+      ),
+      imageUrls: List<String>.from(data['imagemUrls'] ?? []),
+      status: ReportStatus.values.firstWhere(
+        (s) => s.name == data['status'],
+        orElse: () => ReportStatus.pending,
+      ),
+      createdAt: _toDateTime(data['createdAt']),
+      updatedAt: _toDateTime(data['updatedAt']),
+      resolvedAt:
+          data['resolvedAt'] != null ? _toDateTime(data['resolvedAt']) : null,
+    );
+  }
+
+  Map<String, dynamic> toFirestore() {
+    return {
+      'title': title,
+      'description': description,
+      'category': category.name,
+      'isAnonymous': isAnonymous,
+      'userId': userId,
+      'location': location.toMap(),
+      'imagemUrls': imageUrls,
+      'status': status.name,
+      'createdAt': Timestamp.fromDate(createdAt),
+      'updatedAt': Timestamp.fromDate(updatedAt),
+      'resolvedAt':
+          resolvedAt != null ? Timestamp.fromDate(resolvedAt!) : null,
+    };
+  }
+
+  static DateTime _toDateTime(dynamic value) {
+    if (value is Timestamp) return value.toDate();
+    if (value is String) return DateTime.parse(value);
+    return DateTime.now();
+  }
+}
+
+extension ReportCategoryLabel on ReportCategory {
+  String get label {
+    const labels = {
+      ReportCategory.buracos: 'Buracos',
+      ReportCategory.iluminacao: 'Iluminação',
+      ReportCategory.lixo: 'Lixo',
+      ReportCategory.vazamentos: 'Vazamentos',
+      ReportCategory.areasVerdes: 'Áreas Verdes',
+      ReportCategory.outros: 'Outros',
+    };
+    return labels[this]!;
+  }
+
+  IconData get icon {
+    const icons = {
+      ReportCategory.buracos: 0xe3b6, // Icons.warning
+      ReportCategory.iluminacao: 0xe3a9, // Icons.lightbulb
+      ReportCategory.lixo: 0xe1bb, // Icons.delete
+      ReportCategory.vazamentos: 0xe798, // Icons.water_drop
+      ReportCategory.areasVerdes: 0xe3be, // Icons.park
+      ReportCategory.outros: 0xe3c0, // Icons.more_horiz
+    };
+    return IconData(icons[this]!, fontFamily: 'MaterialIcons');
+  }
+}

--- a/cidade_integra/lib/screens/denuncias_screen.dart
+++ b/cidade_integra/lib/screens/denuncias_screen.dart
@@ -1,12 +1,417 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import '../models/report.dart';
+import '../services/report_service.dart';
+import '../utils/app_theme.dart';
+import '../widgets/denuncias/card_denuncia.dart';
 
-class DenunciasScreen extends StatelessWidget {
+class DenunciasScreen extends StatefulWidget {
   const DenunciasScreen({super.key});
 
   @override
+  State<DenunciasScreen> createState() => _DenunciasScreenState();
+}
+
+class _DenunciasScreenState extends State<DenunciasScreen> {
+  final _reportService = ReportService();
+  final _searchController = TextEditingController();
+
+  List<Report> _allReports = [];
+  bool _loading = true;
+  String? _error;
+
+  String? _statusFilter;
+  String? _categoryFilter;
+  String _searchQuery = '';
+  int _currentPage = 0;
+  static const _pageSize = 6;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadReports();
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadReports() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final reports = await _reportService.getReports();
+      if (mounted) {
+        setState(() {
+          _allReports = reports;
+          _loading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = 'Erro ao carregar denúncias.';
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  List<Report> get _filteredReports {
+    var filtered = _allReports;
+
+    if (_statusFilter != null) {
+      filtered = filtered.where((r) => r.status.name == _statusFilter).toList();
+    }
+    if (_categoryFilter != null) {
+      filtered =
+          filtered.where((r) => r.category.name == _categoryFilter).toList();
+    }
+    if (_searchQuery.isNotEmpty) {
+      final q = _searchQuery.toLowerCase();
+      filtered = filtered.where((r) {
+        return r.title.toLowerCase().contains(q) ||
+            r.description.toLowerCase().contains(q) ||
+            r.location.address.toLowerCase().contains(q);
+      }).toList();
+    }
+
+    return filtered;
+  }
+
+  List<Report> get _pagedReports {
+    final start = _currentPage * _pageSize;
+    if (start >= _filteredReports.length) return [];
+    return _filteredReports.skip(start).take(_pageSize).toList();
+  }
+
+  int get _totalPages => (_filteredReports.length / _pageSize).ceil();
+
+  void _resetPage() => setState(() => _currentPage = 0);
+
+  @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text('Denúncias', style: TextStyle(fontSize: 24)),
+    return Column(
+      children: [
+        _buildHeader(),
+        _buildSearchBar(),
+        _buildFilters(),
+        Expanded(child: _buildContent()),
+        if (!_loading && _filteredReports.isNotEmpty) _buildPagination(),
+      ],
     );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(24, 24, 24, 12),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [Colors.grey.shade50, Colors.white],
+        ),
+      ),
+      child: Column(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(14),
+            decoration: BoxDecoration(
+              color: AppColors.verde.withValues(alpha: 0.12),
+              shape: BoxShape.circle,
+            ),
+            child: Icon(Icons.campaign_outlined, size: 32, color: AppColors.verde),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'Denúncias',
+            style: TextStyle(
+              fontSize: 28,
+              fontWeight: FontWeight.w800,
+              color: AppColors.azul,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Acompanhe os problemas reportados pela comunidade.',
+            style: TextStyle(fontSize: 14, color: AppColors.textoSecundario),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSearchBar() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: TextField(
+        controller: _searchController,
+        onChanged: (v) {
+          setState(() => _searchQuery = v);
+          _resetPage();
+        },
+        decoration: InputDecoration(
+          hintText: 'Buscar denúncias...',
+          prefixIcon: const Icon(Icons.search),
+          suffixIcon: _searchQuery.isNotEmpty
+              ? IconButton(
+                  icon: const Icon(Icons.clear),
+                  onPressed: () {
+                    _searchController.clear();
+                    setState(() => _searchQuery = '');
+                    _resetPage();
+                  },
+                )
+              : null,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFilters() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: [
+            _buildFilterChip(
+              label: _statusFilter == null
+                  ? 'Status'
+                  : _statusLabel(_statusFilter!),
+              active: _statusFilter != null,
+              onTap: () => _showStatusFilter(),
+            ),
+            const SizedBox(width: 8),
+            _buildFilterChip(
+              label: _categoryFilter == null
+                  ? 'Categoria'
+                  : _categoryLabel(_categoryFilter!),
+              active: _categoryFilter != null,
+              onTap: () => _showCategoryFilter(),
+            ),
+            if (_statusFilter != null || _categoryFilter != null) ...[
+              const SizedBox(width: 8),
+              ActionChip(
+                label: const Text('Limpar filtros'),
+                avatar: const Icon(Icons.clear, size: 16),
+                onPressed: () {
+                  setState(() {
+                    _statusFilter = null;
+                    _categoryFilter = null;
+                  });
+                  _resetPage();
+                },
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFilterChip({
+    required String label,
+    required bool active,
+    required VoidCallback onTap,
+  }) {
+    return FilterChip(
+      label: Text(label),
+      selected: active,
+      onSelected: (_) => onTap(),
+      selectedColor: AppColors.verde.withValues(alpha: 0.15),
+      checkmarkColor: AppColors.verde,
+    );
+  }
+
+  void _showStatusFilter() {
+    showModalBottomSheet(
+      context: context,
+      builder: (_) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              title: const Text('Todas'),
+              leading: const Icon(Icons.list),
+              selected: _statusFilter == null,
+              onTap: () {
+                setState(() => _statusFilter = null);
+                _resetPage();
+                Navigator.pop(context);
+              },
+            ),
+            for (final s in ReportStatus.values)
+              ListTile(
+                title: Text(_statusLabel(s.name)),
+                selected: _statusFilter == s.name,
+                onTap: () {
+                  setState(() => _statusFilter = s.name);
+                  _resetPage();
+                  Navigator.pop(context);
+                },
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showCategoryFilter() {
+    showModalBottomSheet(
+      context: context,
+      builder: (_) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              title: const Text('Todas'),
+              leading: const Icon(Icons.list),
+              selected: _categoryFilter == null,
+              onTap: () {
+                setState(() => _categoryFilter = null);
+                _resetPage();
+                Navigator.pop(context);
+              },
+            ),
+            for (final c in ReportCategory.values)
+              ListTile(
+                title: Text(c.label),
+                leading: Icon(c.icon),
+                selected: _categoryFilter == c.name,
+                onTap: () {
+                  setState(() => _categoryFilter = c.name);
+                  _resetPage();
+                  Navigator.pop(context);
+                },
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContent() {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error_outline, size: 48, color: AppColors.vermelho),
+            const SizedBox(height: 12),
+            Text(_error!, style: TextStyle(color: AppColors.textoSecundario)),
+            const SizedBox(height: 16),
+            OutlinedButton(
+              onPressed: _loadReports,
+              child: const Text('Tentar novamente'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (_filteredReports.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.search_off, size: 48, color: AppColors.textoSecundario),
+            const SizedBox(height: 12),
+            Text(
+              'Nenhuma denúncia encontrada.',
+              style: TextStyle(fontSize: 16, color: AppColors.textoSecundario),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _loadReports,
+      child: ListView.builder(
+        padding: const EdgeInsets.only(top: 8, bottom: 16),
+        itemCount: _pagedReports.length,
+        itemBuilder: (context, index) {
+          final report = _pagedReports[index];
+          return CardDenuncia(
+            report: report,
+            onTap: () => context.go('/denuncias/${report.id}'),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildPagination() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: AppColors.branco,
+        border: Border(top: BorderSide(color: AppColors.bordas)),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            '${_filteredReports.length} denúncia(s)',
+            style: TextStyle(fontSize: 13, color: AppColors.textoSecundario),
+          ),
+          Row(
+            children: [
+              IconButton(
+                icon: const Icon(Icons.chevron_left),
+                onPressed:
+                    _currentPage > 0
+                        ? () => setState(() => _currentPage--)
+                        : null,
+              ),
+              Text(
+                '${_currentPage + 1} / $_totalPages',
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w500,
+                  color: AppColors.azul,
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.chevron_right),
+                onPressed:
+                    _currentPage < _totalPages - 1
+                        ? () => setState(() => _currentPage++)
+                        : null,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _statusLabel(String status) {
+    const labels = {
+      'pending': 'Pendente',
+      'review': 'Em Análise',
+      'resolved': 'Resolvida',
+      'rejected': 'Rejeitada',
+    };
+    return labels[status] ?? status;
+  }
+
+  String _categoryLabel(String category) {
+    final cat = ReportCategory.values.firstWhere(
+      (c) => c.name == category,
+      orElse: () => ReportCategory.outros,
+    );
+    return cat.label;
   }
 }

--- a/cidade_integra/lib/services/report_service.dart
+++ b/cidade_integra/lib/services/report_service.dart
@@ -1,0 +1,82 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/report.dart';
+
+class ReportService {
+  final _collection = FirebaseFirestore.instance.collection('reports');
+
+  Future<List<Report>> getReports({
+    String? category,
+    String? status,
+    int? limit,
+  }) async {
+    Query query = _collection.orderBy('createdAt', descending: true);
+
+    if (category != null) {
+      query = query.where('category', isEqualTo: category);
+    }
+    if (status != null) {
+      query = query.where('status', isEqualTo: status);
+    }
+    if (limit != null) {
+      query = query.limit(limit);
+    }
+
+    final snapshot = await query.get();
+    return snapshot.docs.map((doc) => Report.fromFirestore(doc)).toList();
+  }
+
+  Future<List<Report>> getReportsByUser(String userId) async {
+    final snapshot = await _collection
+        .where('userId', isEqualTo: userId)
+        .orderBy('createdAt', descending: true)
+        .get();
+    return snapshot.docs.map((doc) => Report.fromFirestore(doc)).toList();
+  }
+
+  Future<Report?> getReportById(String id) async {
+    final doc = await _collection.doc(id).get();
+    if (!doc.exists) return null;
+    return Report.fromFirestore(doc);
+  }
+
+  Future<String> createReport(Report report) async {
+    final data = report.toFirestore();
+    data['createdAt'] = FieldValue.serverTimestamp();
+    data['updatedAt'] = FieldValue.serverTimestamp();
+    data['status'] = ReportStatus.pending.name;
+    data['resolvedAt'] = null;
+
+    final docRef = await _collection.add(data);
+
+    if (report.userId != null) {
+      await FirebaseFirestore.instance
+          .collection('users')
+          .doc(report.userId)
+          .update({'reportCount': FieldValue.increment(1)});
+    }
+
+    return docRef.id;
+  }
+
+  Future<void> updateReportStatus(String id, ReportStatus status) async {
+    final data = <String, dynamic>{
+      'status': status.name,
+      'updatedAt': FieldValue.serverTimestamp(),
+    };
+
+    if (status == ReportStatus.resolved) {
+      data['resolvedAt'] = FieldValue.serverTimestamp();
+    }
+
+    await _collection.doc(id).update(data);
+  }
+
+  Future<void> updateReport(String id, Map<String, dynamic> updates) async {
+    updates['updatedAt'] = FieldValue.serverTimestamp();
+    await _collection.doc(id).update(updates);
+  }
+
+  Future<void> deleteReport(String id) async {
+    await _collection.doc(id).delete();
+  }
+}

--- a/cidade_integra/lib/widgets/denuncias/card_denuncia.dart
+++ b/cidade_integra/lib/widgets/denuncias/card_denuncia.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../../models/report.dart';
+import '../../utils/app_theme.dart';
+import 'status_badge.dart';
+
+class CardDenuncia extends StatelessWidget {
+  final Report report;
+  final VoidCallback onTap;
+
+  const CardDenuncia({super.key, required this.report, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (report.imageUrls.isNotEmpty)
+              SizedBox(
+                height: 160,
+                width: double.infinity,
+                child: Image.network(
+                  report.imageUrls.first,
+                  fit: BoxFit.cover,
+                  errorBuilder: (_, __, ___) => Container(
+                    color: Colors.grey.shade200,
+                    child: const Center(
+                      child: Icon(Icons.broken_image, size: 40, color: Colors.grey),
+                    ),
+                  ),
+                ),
+              ),
+
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          report.title,
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
+                            color: AppColors.azul,
+                          ),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      StatusBadge(status: report.status),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+
+                  if (report.description.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 10),
+                      child: Text(
+                        report.description,
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: AppColors.textoSecundario,
+                          height: 1.3,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 6,
+                    children: [
+                      _InfoChip(
+                        icon: Icon(report.category.icon, size: 14),
+                        label: report.category.label,
+                      ),
+                      if (report.location.address.isNotEmpty)
+                        _InfoChip(
+                          icon: const Icon(Icons.location_on_outlined, size: 14),
+                          label: report.location.address.length > 30
+                              ? '${report.location.address.substring(0, 30)}...'
+                              : report.location.address,
+                        ),
+                      _InfoChip(
+                        icon: const Icon(Icons.calendar_today_outlined, size: 14),
+                        label: DateFormat('dd/MM/yyyy').format(report.createdAt),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InfoChip extends StatelessWidget {
+  final Widget icon;
+  final String label;
+
+  const _InfoChip({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        IconTheme(
+          data: IconThemeData(color: AppColors.textoSecundario, size: 14),
+          child: icon,
+        ),
+        const SizedBox(width: 4),
+        Text(
+          label,
+          style: TextStyle(fontSize: 12, color: AppColors.textoSecundario),
+        ),
+      ],
+    );
+  }
+}

--- a/cidade_integra/lib/widgets/denuncias/status_badge.dart
+++ b/cidade_integra/lib/widgets/denuncias/status_badge.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import '../../models/report.dart';
+
+class StatusBadge extends StatelessWidget {
+  final ReportStatus status;
+  const StatusBadge({super.key, required this.status});
+
+  static const _config = {
+    ReportStatus.pending: ('Pendente', Color(0xFFF39C12), Color(0xFFFFF3CD)),
+    ReportStatus.review: ('Em Análise', Color(0xFF3498DB), Color(0xFFD6EAF8)),
+    ReportStatus.resolved: ('Resolvida', Color(0xFF2ECC71), Color(0xFFD5F5E3)),
+    ReportStatus.rejected: ('Rejeitada', Color(0xFFE74C3C), Color(0xFFFADCD5)),
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final (label, textColor, bgColor) = _config[status]!;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: textColor,
+          fontWeight: FontWeight.w600,
+          fontSize: 12,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### 🟣 [UI | 8 pontos] Tela de Listagem de Denúncias com Filtros e Paginação

#### 🧩 Descrição
Criar a tela que lista todas as denúncias vindas do Firestore. Incluir filtros por categoria e status, busca por texto e paginação. Cada denúncia é exibida como um card com título, categoria, status e data.

#### 🎯 Objetivo e Critérios de Aceite
- [x] Tela `lib/screens/denuncias_screen.dart` criada.
- [x] Widget `lib/widgets/denuncias/card_denuncia.dart` criado.
- [x] Lista exibe denúncias usando dados do Firestore via `ReportService`.
- [x] Filtro por categoria funcional (bottom sheet).
- [x] Filtro por status funcional (bottom sheet).
- [x] Busca por texto (título, descrição, endereço).
- [x] Cada card exibe: título, categoria (com ícone), status (com badge colorido), data formatada, endereço resumido.
- [x] Ao clicar em um card, navega para `/denuncias/:id`.
- [x] Estado de loading (indicador de progresso) enquanto carrega.
- [x] Estado vazio ("Nenhuma denúncia encontrada") quando não há resultados.

#### Extras
- Widget `StatusBadge` reutilizável com cores por status (amarelo, azul, verde, vermelho).
- Widget `CardDenuncia` com imagem de capa, chips de info e truncamento inteligente.
- Paginação client-side com 6 itens por página e navegação anterior/próximo.
- Pull-to-refresh via `RefreshIndicator`.
- Estado de erro com botão "Tentar novamente".
- Botão "Limpar filtros" quando algum filtro está ativo.