### PR TITLE
🟣 [UI | 3 pontos] Widget StatusFlow — Fluxo Visual de Status

### DIFF
--- a/cidade_integra/lib/screens/denuncia_detalhes_screen.dart
+++ b/cidade_integra/lib/screens/denuncia_detalhes_screen.dart
@@ -5,6 +5,7 @@ import '../models/report.dart';
 import '../services/report_service.dart';
 import '../utils/app_theme.dart';
 import '../widgets/denuncias/status_badge.dart';
+import '../widgets/denuncias/status_flow.dart';
 
 class DenunciaDetalhesScreen extends StatelessWidget {
   final String reportId;
@@ -145,6 +146,13 @@ class _DetailContent extends StatelessWidget {
                 ),
             ],
           ),
+        ),
+
+        const Divider(height: 1),
+
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: StatusFlow(currentStatus: report.status),
         ),
       ],
     );

--- a/cidade_integra/lib/screens/denuncia_detalhes_screen.dart
+++ b/cidade_integra/lib/screens/denuncia_detalhes_screen.dart
@@ -1,4 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import '../models/report.dart';
+import '../services/report_service.dart';
+import '../utils/app_theme.dart';
+import '../widgets/denuncias/status_badge.dart';
 
 class DenunciaDetalhesScreen extends StatelessWidget {
   final String reportId;
@@ -6,8 +12,324 @@ class DenunciaDetalhesScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    return FutureBuilder<Report?>(
+      future: ReportService().getReportById(reportId),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        if (snapshot.hasError) {
+          return _ErrorState(onRetry: () => context.go('/denuncias/$reportId'));
+        }
+
+        final report = snapshot.data;
+        if (report == null) {
+          return _NotFoundState();
+        }
+
+        return _DetailContent(report: report);
+      },
+    );
+  }
+}
+
+class _DetailContent extends StatelessWidget {
+  final Report report;
+  const _DetailContent({required this.report});
+
+  @override
+  Widget build(BuildContext context) {
+    final dateFormat = DateFormat("dd 'de' MMMM 'de' yyyy", 'pt_BR');
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Header azul
+        Container(
+          width: double.infinity,
+          color: AppColors.azul,
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              GestureDetector(
+                onTap: () => context.go('/denuncias'),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.arrow_back, size: 16, color: Colors.white.withValues(alpha: 0.8)),
+                    const SizedBox(width: 6),
+                    Text(
+                      'Voltar para denúncias',
+                      style: TextStyle(color: Colors.white.withValues(alpha: 0.8), fontSize: 13),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 14),
+              Text(
+                report.title,
+                style: const TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.w700,
+                  color: Colors.white,
+                ),
+              ),
+              const SizedBox(height: 10),
+              StatusBadge(status: report.status),
+            ],
+          ),
+        ),
+
+        // Galeria de imagens
+        if (report.imageUrls.isNotEmpty) _ImageGallery(urls: report.imageUrls),
+
+        // Descrição
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _SectionTitle(title: 'Descrição'),
+              const SizedBox(height: 8),
+              Text(
+                report.description,
+                style: TextStyle(
+                  fontSize: 15,
+                  color: AppColors.preto,
+                  height: 1.5,
+                ),
+              ),
+            ],
+          ),
+        ),
+
+        const Divider(height: 1),
+
+        // Informações
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _SectionTitle(title: 'Informações'),
+              const SizedBox(height: 12),
+              _InfoRow(
+                icon: Icons.category_outlined,
+                label: 'Categoria',
+                value: report.category.label,
+              ),
+              _InfoRow(
+                icon: Icons.location_on_outlined,
+                label: 'Localização',
+                value: report.location.address.isNotEmpty
+                    ? report.location.address
+                    : '—',
+              ),
+              _InfoRow(
+                icon: Icons.calendar_today_outlined,
+                label: 'Data de Registro',
+                value: dateFormat.format(report.createdAt),
+              ),
+              _InfoRow(
+                icon: Icons.person_outline,
+                label: 'Reportado por',
+                value: report.isAnonymous ? 'Anônimo' : 'Cidadão',
+              ),
+              if (report.resolvedAt != null)
+                _InfoRow(
+                  icon: Icons.check_circle_outline,
+                  label: 'Resolvida em',
+                  value: dateFormat.format(report.resolvedAt!),
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ImageGallery extends StatefulWidget {
+  final List<String> urls;
+  const _ImageGallery({required this.urls});
+
+  @override
+  State<_ImageGallery> createState() => _ImageGalleryState();
+}
+
+class _ImageGalleryState extends State<_ImageGallery> {
+  int _current = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        SizedBox(
+          height: 240,
+          child: PageView.builder(
+            itemCount: widget.urls.length,
+            onPageChanged: (i) => setState(() => _current = i),
+            itemBuilder: (_, i) => Image.network(
+              widget.urls[i],
+              fit: BoxFit.cover,
+              width: double.infinity,
+              errorBuilder: (_, __, ___) => Container(
+                color: Colors.grey.shade200,
+                child: const Center(
+                  child: Icon(Icons.broken_image, size: 48, color: Colors.grey),
+                ),
+              ),
+            ),
+          ),
+        ),
+        if (widget.urls.length > 1)
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: List.generate(
+                widget.urls.length,
+                (i) => Container(
+                  margin: const EdgeInsets.symmetric(horizontal: 3),
+                  width: _current == i ? 10 : 7,
+                  height: _current == i ? 10 : 7,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: _current == i ? AppColors.verde : AppColors.cinza,
+                  ),
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _SectionTitle extends StatelessWidget {
+  final String title;
+  const _SectionTitle({required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      title,
+      style: TextStyle(
+        fontSize: 18,
+        fontWeight: FontWeight.w700,
+        color: AppColors.azul,
+      ),
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+
+  const _InfoRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, size: 20, color: AppColors.textoSecundario),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: AppColors.textoSecundario,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  value,
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                    color: AppColors.azul,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NotFoundState extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
     return Center(
-      child: Text('Detalhes da Denúncia: $reportId', style: const TextStyle(fontSize: 24)),
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.search_off, size: 64, color: AppColors.textoSecundario),
+            const SizedBox(height: 16),
+            Text(
+              'Denúncia não encontrada',
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.w600,
+                color: AppColors.azul,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'A denúncia que você procura não existe ou foi removida.',
+              style: TextStyle(color: AppColors.textoSecundario),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            OutlinedButton.icon(
+              onPressed: () => context.go('/denuncias'),
+              icon: const Icon(Icons.arrow_back, size: 18),
+              label: const Text('Voltar para Denúncias'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  final VoidCallback onRetry;
+  const _ErrorState({required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.error_outline, size: 48, color: AppColors.vermelho),
+          const SizedBox(height: 12),
+          Text('Erro ao carregar denúncia.',
+              style: TextStyle(color: AppColors.textoSecundario)),
+          const SizedBox(height: 16),
+          OutlinedButton(onPressed: onRetry, child: const Text('Tentar novamente')),
+        ],
+      ),
     );
   }
 }

--- a/cidade_integra/lib/widgets/denuncias/status_flow.dart
+++ b/cidade_integra/lib/widgets/denuncias/status_flow.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+import '../../models/report.dart';
+import '../../utils/app_theme.dart';
+
+class StatusFlow extends StatelessWidget {
+  final ReportStatus currentStatus;
+  const StatusFlow({super.key, required this.currentStatus});
+
+  @override
+  Widget build(BuildContext context) {
+    final isRejected = currentStatus == ReportStatus.rejected;
+
+    final steps = [
+      _Step(ReportStatus.pending, 'Pendente', Icons.hourglass_empty),
+      _Step(ReportStatus.review, 'Em Análise', Icons.search),
+      _Step(
+        ReportStatus.resolved,
+        isRejected ? 'Rejeitada' : 'Resolvida',
+        isRejected ? Icons.close : Icons.check_circle,
+      ),
+    ];
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppColors.branco,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.bordas),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Status da Denúncia',
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              color: AppColors.azul,
+            ),
+          ),
+          const SizedBox(height: 20),
+          ...List.generate(steps.length, (i) {
+            final step = steps[i];
+            final state = _getStepState(step.status, currentStatus, isRejected);
+            final isLast = i == steps.length - 1;
+
+            return _StepRow(
+              step: step,
+              state: state,
+              isRejected: isRejected && isLast,
+              showLine: !isLast,
+            );
+          }),
+        ],
+      ),
+    );
+  }
+
+  _StepState _getStepState(
+    ReportStatus step,
+    ReportStatus current,
+    bool isRejected,
+  ) {
+    if (isRejected) {
+      if (step == ReportStatus.resolved) return _StepState.rejected;
+      return _StepState.completed;
+    }
+    if (current.index > step.index) return _StepState.completed;
+    if (current == step) return _StepState.current;
+    return _StepState.upcoming;
+  }
+}
+
+enum _StepState { completed, current, upcoming, rejected }
+
+class _Step {
+  final ReportStatus status;
+  final String label;
+  final IconData icon;
+  const _Step(this.status, this.label, this.icon);
+}
+
+class _StepRow extends StatelessWidget {
+  final _Step step;
+  final _StepState state;
+  final bool isRejected;
+  final bool showLine;
+
+  const _StepRow({
+    required this.step,
+    required this.state,
+    required this.isRejected,
+    required this.showLine,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = switch (state) {
+      _StepState.completed => AppColors.verde,
+      _StepState.current => AppColors.verde,
+      _StepState.rejected => AppColors.vermelho,
+      _StepState.upcoming => AppColors.cinza,
+    };
+
+    final subtext = switch (state) {
+      _StepState.current => 'Status atual',
+      _StepState.completed => 'Concluído',
+      _StepState.rejected => 'Denúncia rejeitada',
+      _StepState.upcoming => '',
+    };
+
+    return Column(
+      children: [
+        Row(
+          children: [
+            Container(
+              width: 36,
+              height: 36,
+              decoration: BoxDecoration(
+                color: state == _StepState.upcoming
+                    ? Colors.grey.shade200
+                    : color.withValues(alpha: 0.15),
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                step.icon,
+                size: 18,
+                color: state == _StepState.upcoming
+                    ? Colors.grey.shade400
+                    : color,
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    step.label,
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      color: state == _StepState.upcoming
+                          ? AppColors.textoSecundario
+                          : AppColors.azul,
+                    ),
+                  ),
+                  if (subtext.isNotEmpty)
+                    Text(
+                      subtext,
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: isRejected
+                            ? AppColors.vermelho
+                            : AppColors.textoSecundario,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        if (showLine)
+          Padding(
+            padding: const EdgeInsets.only(left: 17),
+            child: Container(
+              width: 2,
+              height: 24,
+              color: state == _StepState.upcoming
+                  ? Colors.grey.shade200
+                  : color.withValues(alpha: 0.3),
+            ),
+          ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
### 🟣 [UI | 3 pontos] Widget StatusFlow — Fluxo Visual de Status

#### 🧩 Descrição
Criar um widget que exibe o fluxo de status de uma denúncia como um stepper visual vertical. Os passos são: Pendente → Em Análise → Resolvida (ou Rejeitada). O passo atual é destacado.

#### 🎯 Objetivo e Critérios de Aceite
- [x] Widget `lib/widgets/denuncias/status_flow.dart` criado.
- [x] Exibe os 3 passos de status com ícones e rótulos.
- [x] O passo atual e os anteriores ficam com cor preenchida (verde).
- [x] Passos futuros ficam desabilitados (cinza).
- [x] Se o status for `rejected`, o último passo exibe "Rejeitada" com cor vermelha.
- [x] Usado na tela de detalhes da denúncia.

#### Implementação
- Timeline vertical com ícones circulares, rótulos e linhas de conexão.
- Subtextos contextuais: "Status atual", "Concluído", "Denúncia rejeitada".
- Integrado na `DenunciaDetalhesScreen` após a seção de Informações.