### PR TITLE
🔵 [Integração | 3 pontos] Modelo de Dados User e Serviço Firestore

### DIFF
--- a/cidade_integra/lib/models/app_user.dart
+++ b/cidade_integra/lib/models/app_user.dart
@@ -1,0 +1,81 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class AppUser {
+  final String uid;
+  final String displayName;
+  final String email;
+  final String photoURL;
+  final String role;
+  final String createdAt;
+  final int score;
+  final int reportCount;
+  final String lastLoginAt;
+  final String region;
+  final bool verified;
+  final String bio;
+  final String status;
+
+  const AppUser({
+    required this.uid,
+    required this.displayName,
+    required this.email,
+    this.photoURL = '',
+    this.role = 'user',
+    required this.createdAt,
+    this.score = 0,
+    this.reportCount = 0,
+    required this.lastLoginAt,
+    this.region = '',
+    this.verified = false,
+    this.bio = '',
+    this.status = 'active',
+  });
+
+  bool get isAdmin => role == 'admin';
+
+  factory AppUser.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return AppUser(
+      uid: doc.id,
+      displayName: data['displayName'] ?? '',
+      email: data['email'] ?? '',
+      photoURL: data['photoURL'] ?? '',
+      role: data['role'] ?? 'user',
+      createdAt: data['createdAt'] ?? '',
+      score: data['score'] ?? 0,
+      reportCount: data['reportCount'] ?? 0,
+      lastLoginAt: data['lastLoginAt'] ?? '',
+      region: data['region'] ?? '',
+      verified: data['verified'] ?? false,
+      bio: data['bio'] ?? '',
+      status: data['status'] ?? 'active',
+    );
+  }
+
+  AppUser copyWith({
+    String? displayName,
+    String? photoURL,
+    String? bio,
+    String? region,
+    int? score,
+    int? reportCount,
+    bool? verified,
+    String? status,
+  }) {
+    return AppUser(
+      uid: uid,
+      displayName: displayName ?? this.displayName,
+      email: email,
+      photoURL: photoURL ?? this.photoURL,
+      role: role,
+      createdAt: createdAt,
+      score: score ?? this.score,
+      reportCount: reportCount ?? this.reportCount,
+      lastLoginAt: lastLoginAt,
+      region: region ?? this.region,
+      verified: verified ?? this.verified,
+      bio: bio ?? this.bio,
+      status: status ?? this.status,
+    );
+  }
+}

--- a/cidade_integra/lib/services/user_service.dart
+++ b/cidade_integra/lib/services/user_service.dart
@@ -1,0 +1,42 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../models/app_user.dart';
+
+class UserService {
+  final _collection = FirebaseFirestore.instance.collection('users');
+
+  Future<AppUser?> getUserById(String uid) async {
+    final doc = await _collection.doc(uid).get();
+    if (!doc.exists) return null;
+    return AppUser.fromFirestore(doc);
+  }
+
+  Future<void> updateUser(String uid, Map<String, dynamic> data) async {
+    await _collection.doc(uid).update(data);
+  }
+
+  Future<void> updateProfile({
+    required String uid,
+    required String displayName,
+    String? bio,
+    String? region,
+  }) async {
+    await _collection.doc(uid).update({
+      'displayName': displayName,
+      if (bio != null) 'bio': bio,
+      if (region != null) 'region': region,
+    });
+
+    await FirebaseAuth.instance.currentUser?.updateDisplayName(displayName);
+  }
+
+  Future<void> deactivateAccount(String uid) async {
+    await _collection.doc(uid).update({'status': 'inactive'});
+    await FirebaseAuth.instance.signOut();
+  }
+
+  Future<int> getTotalUsers() async {
+    final snapshot = await _collection.count().get();
+    return snapshot.count ?? 0;
+  }
+}


### PR DESCRIPTION
### 🔵 [Integração | 3 pontos] Modelo de Dados User e Serviço Firestore

#### 🧩 Descrição
Criar a classe Dart `AppUser` que representa o documento de usuário no Firestore (coleção `users`) e o serviço que encapsula as operações de leitura e atualização do perfil.

#### 🎯 Objetivo e Critérios de Aceite
- [x] Arquivo `lib/models/app_user.dart` criado.
- [x] Classe `AppUser` com campos: `uid`, `displayName`, `email`, `photoURL`, `role`, `createdAt`, `score`, `reportCount`, `lastLoginAt`, `region`, `verified`, `bio`, `status`.
- [x] Método `factory AppUser.fromFirestore(DocumentSnapshot doc)`.
- [x] Método `copyWith` para atualizações imutáveis.
- [x] Arquivo `lib/services/user_service.dart` criado.
- [x] Métodos: `getUserById(uid)`, `updateUser(uid, data)`, `updateProfile(uid, displayName, bio, region)`, `deactivateAccount(uid)`, `getTotalUsers()`.