### PR TITLE
🔵 [Integração | 5 pontos] Minhas Denúncias e Denúncias Salvas

### DIFF
--- a/cidade_integra/lib/models/app_user.dart
+++ b/cidade_integra/lib/models/app_user.dart
@@ -1,0 +1,81 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class AppUser {
+  final String uid;
+  final String displayName;
+  final String email;
+  final String photoURL;
+  final String role;
+  final String createdAt;
+  final int score;
+  final int reportCount;
+  final String lastLoginAt;
+  final String region;
+  final bool verified;
+  final String bio;
+  final String status;
+
+  const AppUser({
+    required this.uid,
+    required this.displayName,
+    required this.email,
+    this.photoURL = '',
+    this.role = 'user',
+    required this.createdAt,
+    this.score = 0,
+    this.reportCount = 0,
+    required this.lastLoginAt,
+    this.region = '',
+    this.verified = false,
+    this.bio = '',
+    this.status = 'active',
+  });
+
+  bool get isAdmin => role == 'admin';
+
+  factory AppUser.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return AppUser(
+      uid: doc.id,
+      displayName: data['displayName'] ?? '',
+      email: data['email'] ?? '',
+      photoURL: data['photoURL'] ?? '',
+      role: data['role'] ?? 'user',
+      createdAt: data['createdAt'] ?? '',
+      score: data['score'] ?? 0,
+      reportCount: data['reportCount'] ?? 0,
+      lastLoginAt: data['lastLoginAt'] ?? '',
+      region: data['region'] ?? '',
+      verified: data['verified'] ?? false,
+      bio: data['bio'] ?? '',
+      status: data['status'] ?? 'active',
+    );
+  }
+
+  AppUser copyWith({
+    String? displayName,
+    String? photoURL,
+    String? bio,
+    String? region,
+    int? score,
+    int? reportCount,
+    bool? verified,
+    String? status,
+  }) {
+    return AppUser(
+      uid: uid,
+      displayName: displayName ?? this.displayName,
+      email: email,
+      photoURL: photoURL ?? this.photoURL,
+      role: role,
+      createdAt: createdAt,
+      score: score ?? this.score,
+      reportCount: reportCount ?? this.reportCount,
+      lastLoginAt: lastLoginAt,
+      region: region ?? this.region,
+      verified: verified ?? this.verified,
+      bio: bio ?? this.bio,
+      status: status ?? this.status,
+    );
+  }
+}

--- a/cidade_integra/lib/routes/app_router.dart
+++ b/cidade_integra/lib/routes/app_router.dart
@@ -6,6 +6,7 @@ import '../screens/home_screen.dart';
 import '../screens/denuncias_screen.dart';
 import '../screens/denuncia_detalhes_screen.dart';
 import '../screens/nova_denuncia_screen.dart';
+import '../screens/editar_perfil_screen.dart';
 import '../screens/login_screen.dart';
 import '../screens/register_screen.dart';
 import '../screens/recuperar_senha_screen.dart';
@@ -21,7 +22,7 @@ import '../screens/admin/admin_usuarios_screen.dart';
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
 final _shellNavigatorKey = GlobalKey<NavigatorState>();
 
-const _protectedRoutes = ['/nova-denuncia', '/perfil'];
+const _protectedRoutes = ['/nova-denuncia', '/perfil', '/perfil/editar'];
 const _adminRoutes = ['/admin', '/admin/denuncias', '/admin/usuarios'];
 const _authRoutes = ['/login', '/registro', '/recuperar-senha'];
 
@@ -96,6 +97,10 @@ GoRouter buildRouter(AuthProvider auth) {
           GoRoute(
             path: '/perfil',
             builder: (context, state) => const PerfilScreen(),
+          ),
+          GoRoute(
+            path: '/perfil/editar',
+            builder: (context, state) => const EditarPerfilScreen(),
           ),
           GoRoute(
             path: '/admin',

--- a/cidade_integra/lib/screens/editar_perfil_screen.dart
+++ b/cidade_integra/lib/screens/editar_perfil_screen.dart
@@ -1,0 +1,277 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+import '../models/app_user.dart';
+import '../providers/auth_provider.dart';
+import '../services/user_service.dart';
+import '../utils/app_theme.dart';
+
+class EditarPerfilScreen extends StatelessWidget {
+  const EditarPerfilScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = context.watch<AuthProvider>();
+
+    if (!auth.isLoggedIn) {
+      return const Center(child: Text('Faça login para editar seu perfil.'));
+    }
+
+    return FutureBuilder<AppUser?>(
+      future: UserService().getUserById(auth.user!.uid),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final user = snapshot.data;
+        if (user == null) {
+          return const Center(child: Text('Usuário não encontrado.'));
+        }
+        return _EditForm(user: user);
+      },
+    );
+  }
+}
+
+class _EditForm extends StatefulWidget {
+  final AppUser user;
+  const _EditForm({required this.user});
+
+  @override
+  State<_EditForm> createState() => _EditFormState();
+}
+
+class _EditFormState extends State<_EditForm> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _nomeController;
+  late final TextEditingController _bioController;
+  late final TextEditingController _regiaoController;
+  bool _loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _nomeController = TextEditingController(text: widget.user.displayName);
+    _bioController = TextEditingController(text: widget.user.bio);
+    _regiaoController = TextEditingController(text: widget.user.region);
+  }
+
+  @override
+  void dispose() {
+    _nomeController.dispose();
+    _bioController.dispose();
+    _regiaoController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _salvar() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() => _loading = true);
+
+    try {
+      await UserService().updateProfile(
+        uid: widget.user.uid,
+        displayName: _nomeController.text.trim(),
+        bio: _bioController.text.trim(),
+        region: _regiaoController.text.trim(),
+      );
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Perfil atualizado com sucesso!')),
+        );
+        context.go('/perfil');
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Erro ao atualizar perfil.')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  void _confirmarDesativacao() {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Desativar Conta'),
+        content: const Text(
+          'Tem certeza que deseja desativar sua conta? '
+          'Você poderá reativá-la entrando em contato com o suporte.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancelar'),
+          ),
+          ElevatedButton(
+            onPressed: () async {
+              Navigator.pop(ctx);
+              await UserService().deactivateAccount(widget.user.uid);
+              if (mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Conta desativada com sucesso.'),
+                  ),
+                );
+                context.go('/login');
+              }
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppColors.vermelho,
+            ),
+            child: const Text('Desativar'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [Colors.grey.shade50, Colors.white],
+            ),
+          ),
+          child: Column(
+            children: [
+              Text(
+                'Editar Perfil',
+                style: TextStyle(
+                  fontSize: 26,
+                  fontWeight: FontWeight.w800,
+                  color: AppColors.azul,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'Atualize suas informações pessoais.',
+                style: TextStyle(
+                  fontSize: 14,
+                  color: AppColors.textoSecundario,
+                ),
+              ),
+            ],
+          ),
+        ),
+
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                TextFormField(
+                  controller: _nomeController,
+                  textInputAction: TextInputAction.next,
+                  decoration: const InputDecoration(
+                    labelText: 'Nome de exibição *',
+                    prefixIcon: Icon(Icons.person_outline),
+                  ),
+                  validator: (v) {
+                    if (v == null || v.trim().isEmpty) {
+                      return 'O nome não pode ser vazio';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+
+                TextFormField(
+                  controller: _bioController,
+                  maxLines: 3,
+                  maxLength: 200,
+                  textInputAction: TextInputAction.next,
+                  decoration: const InputDecoration(
+                    labelText: 'Bio',
+                    hintText: 'Conte um pouco sobre você...',
+                    prefixIcon: Icon(Icons.info_outline),
+                    alignLabelWithHint: true,
+                  ),
+                ),
+                const SizedBox(height: 16),
+
+                TextFormField(
+                  controller: _regiaoController,
+                  textInputAction: TextInputAction.done,
+                  decoration: const InputDecoration(
+                    labelText: 'Região',
+                    hintText: 'Ex: São Paulo - SP',
+                    prefixIcon: Icon(Icons.location_on_outlined),
+                  ),
+                ),
+                const SizedBox(height: 24),
+
+                SizedBox(
+                  height: 48,
+                  child: ElevatedButton.icon(
+                    onPressed: _loading ? null : _salvar,
+                    icon: _loading
+                        ? const SizedBox(
+                            height: 20,
+                            width: 20,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: Colors.white,
+                            ),
+                          )
+                        : const Icon(Icons.save_outlined, size: 20),
+                    label: Text(_loading ? 'Salvando...' : 'Salvar'),
+                  ),
+                ),
+                const SizedBox(height: 12),
+
+                SizedBox(
+                  height: 48,
+                  child: OutlinedButton.icon(
+                    onPressed: () => context.go('/perfil'),
+                    icon: const Icon(Icons.arrow_back, size: 18),
+                    label: const Text('Cancelar'),
+                  ),
+                ),
+
+                const SizedBox(height: 32),
+                const Divider(),
+                const SizedBox(height: 16),
+
+                Text(
+                  'Zona de Perigo',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.vermelho,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                SizedBox(
+                  height: 48,
+                  child: OutlinedButton.icon(
+                    onPressed: _confirmarDesativacao,
+                    icon: const Icon(Icons.block, size: 18),
+                    label: const Text('Desativar Conta'),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: AppColors.vermelho,
+                      side: const BorderSide(color: AppColors.vermelho),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/cidade_integra/lib/screens/perfil_screen.dart
+++ b/cidade_integra/lib/screens/perfil_screen.dart
@@ -1,12 +1,282 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+import '../models/app_user.dart';
+import '../providers/auth_provider.dart';
+import '../services/user_service.dart';
+import '../utils/app_theme.dart';
 
 class PerfilScreen extends StatelessWidget {
   const PerfilScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text('Perfil', style: TextStyle(fontSize: 24)),
+    final auth = context.watch<AuthProvider>();
+
+    if (!auth.isLoggedIn) {
+      return const Center(child: Text('Faça login para ver seu perfil.'));
+    }
+
+    return FutureBuilder<AppUser?>(
+      future: UserService().getUserById(auth.user!.uid),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        final user = snapshot.data;
+        if (user == null) {
+          return const Center(child: Text('Usuário não encontrado.'));
+        }
+
+        return _ProfileContent(user: user);
+      },
+    );
+  }
+}
+
+class _ProfileContent extends StatelessWidget {
+  final AppUser user;
+  const _ProfileContent({required this.user});
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = context.read<AuthProvider>();
+
+    return Column(
+      children: [
+        // Header do perfil
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 24),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [
+                AppColors.azul,
+                AppColors.azul.withValues(alpha: 0.85),
+              ],
+            ),
+          ),
+          child: Column(
+            children: [
+              CircleAvatar(
+                radius: 48,
+                backgroundColor: AppColors.verde,
+                backgroundImage: user.photoURL.isNotEmpty
+                    ? NetworkImage(user.photoURL)
+                    : null,
+                child: user.photoURL.isEmpty
+                    ? Text(
+                        user.displayName.isNotEmpty
+                            ? user.displayName[0].toUpperCase()
+                            : '?',
+                        style: const TextStyle(
+                          fontSize: 36,
+                          fontWeight: FontWeight.w700,
+                          color: Colors.white,
+                        ),
+                      )
+                    : null,
+              ),
+              const SizedBox(height: 14),
+              Text(
+                user.displayName,
+                style: const TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.w700,
+                  color: Colors.white,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                user.email,
+                style: TextStyle(
+                  fontSize: 14,
+                  color: Colors.white.withValues(alpha: 0.7),
+                ),
+              ),
+              if (user.bio.isNotEmpty) ...[
+                const SizedBox(height: 10),
+                Text(
+                  user.bio,
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: Colors.white.withValues(alpha: 0.8),
+                    height: 1.3,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+              if (user.region.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.location_on_outlined,
+                        size: 14, color: Colors.white.withValues(alpha: 0.7)),
+                    const SizedBox(width: 4),
+                    Text(
+                      user.region,
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Colors.white.withValues(alpha: 0.7),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ],
+          ),
+        ),
+
+        // Estatísticas
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              Expanded(
+                child: _StatCard(
+                  icon: Icons.campaign_outlined,
+                  label: 'Denúncias',
+                  value: '${user.reportCount}',
+                  color: AppColors.verde,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _StatCard(
+                  icon: Icons.star_outline,
+                  label: 'Score',
+                  value: '${user.score}',
+                  color: const Color(0xFFF39C12),
+                ),
+              ),
+            ],
+          ),
+        ),
+
+        // Badges placeholder
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: AppColors.branco,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: AppColors.bordas),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Icon(Icons.emoji_events_outlined,
+                        size: 20, color: AppColors.azul),
+                    const SizedBox(width: 8),
+                    Text(
+                      'Conquistas',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w700,
+                        color: AppColors.azul,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  'Em breve suas badges aparecerão aqui.',
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: AppColors.textoSecundario,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+
+        // Ações
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              OutlinedButton.icon(
+                onPressed: () => context.go('/perfil/editar'),
+                icon: const Icon(Icons.edit_outlined, size: 18),
+                label: const Text('Editar Perfil'),
+              ),
+              const SizedBox(height: 8),
+              OutlinedButton.icon(
+                onPressed: () async {
+                  await auth.logout();
+                  if (context.mounted) context.go('/');
+                },
+                icon: const Icon(Icons.logout, size: 18),
+                label: const Text('Sair'),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: AppColors.vermelho,
+                  side: const BorderSide(color: AppColors.vermelho),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 24),
+      ],
+    );
+  }
+}
+
+class _StatCard extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+  final Color color;
+
+  const _StatCard({
+    required this.icon,
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.2)),
+      ),
+      child: Column(
+        children: [
+          Icon(icon, size: 28, color: color),
+          const SizedBox(height: 8),
+          Text(
+            value,
+            style: TextStyle(
+              fontSize: 24,
+              fontWeight: FontWeight.w800,
+              color: color,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 12,
+              color: AppColors.textoSecundario,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/cidade_integra/lib/screens/perfil_screen.dart
+++ b/cidade_integra/lib/screens/perfil_screen.dart
@@ -5,6 +5,7 @@ import '../models/app_user.dart';
 import '../providers/auth_provider.dart';
 import '../services/user_service.dart';
 import '../utils/app_theme.dart';
+import '../widgets/perfil/badges_display.dart';
 
 class PerfilScreen extends StatelessWidget {
   const PerfilScreen({super.key});
@@ -157,46 +158,9 @@ class _ProfileContent extends StatelessWidget {
           ),
         ),
 
-        // Badges placeholder
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: Container(
-            width: double.infinity,
-            padding: const EdgeInsets.all(16),
-            decoration: BoxDecoration(
-              color: AppColors.branco,
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(color: AppColors.bordas),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    Icon(Icons.emoji_events_outlined,
-                        size: 20, color: AppColors.azul),
-                    const SizedBox(width: 8),
-                    Text(
-                      'Conquistas',
-                      style: TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w700,
-                        color: AppColors.azul,
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 12),
-                Text(
-                  'Em breve suas badges aparecerão aqui.',
-                  style: TextStyle(
-                    fontSize: 13,
-                    color: AppColors.textoSecundario,
-                  ),
-                ),
-              ],
-            ),
-          ),
+          child: BadgesDisplay(user: user),
         ),
         const SizedBox(height: 16),
 

--- a/cidade_integra/lib/screens/perfil_screen.dart
+++ b/cidade_integra/lib/screens/perfil_screen.dart
@@ -6,6 +6,7 @@ import '../providers/auth_provider.dart';
 import '../services/user_service.dart';
 import '../utils/app_theme.dart';
 import '../widgets/perfil/badges_display.dart';
+import '../widgets/perfil/minhas_denuncias.dart';
 
 class PerfilScreen extends StatelessWidget {
   const PerfilScreen({super.key});
@@ -162,6 +163,9 @@ class _ProfileContent extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: BadgesDisplay(user: user),
         ),
+        const SizedBox(height: 16),
+
+        MinhasDenuncias(userId: user.uid),
         const SizedBox(height: 16),
 
         // Ações

--- a/cidade_integra/lib/services/saved_reports_service.dart
+++ b/cidade_integra/lib/services/saved_reports_service.dart
@@ -1,0 +1,47 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/report.dart';
+
+class SavedReportsService {
+  CollectionReference _savedRef(String uid) {
+    return FirebaseFirestore.instance
+        .collection('users')
+        .doc(uid)
+        .collection('savedReports');
+  }
+
+  Future<void> saveReport(String uid, String reportId) async {
+    await _savedRef(uid).doc(reportId).set({
+      'savedAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  Future<void> removeReport(String uid, String reportId) async {
+    await _savedRef(uid).doc(reportId).delete();
+  }
+
+  Future<bool> isSaved(String uid, String reportId) async {
+    final doc = await _savedRef(uid).doc(reportId).get();
+    return doc.exists;
+  }
+
+  Future<List<Report>> getSavedReports(String uid) async {
+    final savedDocs = await _savedRef(uid)
+        .orderBy('savedAt', descending: true)
+        .get();
+
+    final reportIds = savedDocs.docs.map((d) => d.id).toList();
+    if (reportIds.isEmpty) return [];
+
+    final reports = <Report>[];
+    for (final id in reportIds) {
+      final doc = await FirebaseFirestore.instance
+          .collection('reports')
+          .doc(id)
+          .get();
+      if (doc.exists) {
+        reports.add(Report.fromFirestore(doc));
+      }
+    }
+    return reports;
+  }
+}

--- a/cidade_integra/lib/services/user_service.dart
+++ b/cidade_integra/lib/services/user_service.dart
@@ -1,0 +1,42 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../models/app_user.dart';
+
+class UserService {
+  final _collection = FirebaseFirestore.instance.collection('users');
+
+  Future<AppUser?> getUserById(String uid) async {
+    final doc = await _collection.doc(uid).get();
+    if (!doc.exists) return null;
+    return AppUser.fromFirestore(doc);
+  }
+
+  Future<void> updateUser(String uid, Map<String, dynamic> data) async {
+    await _collection.doc(uid).update(data);
+  }
+
+  Future<void> updateProfile({
+    required String uid,
+    required String displayName,
+    String? bio,
+    String? region,
+  }) async {
+    await _collection.doc(uid).update({
+      'displayName': displayName,
+      if (bio != null) 'bio': bio,
+      if (region != null) 'region': region,
+    });
+
+    await FirebaseAuth.instance.currentUser?.updateDisplayName(displayName);
+  }
+
+  Future<void> deactivateAccount(String uid) async {
+    await _collection.doc(uid).update({'status': 'inactive'});
+    await FirebaseAuth.instance.signOut();
+  }
+
+  Future<int> getTotalUsers() async {
+    final snapshot = await _collection.count().get();
+    return snapshot.count ?? 0;
+  }
+}

--- a/cidade_integra/lib/utils/badge_rules.dart
+++ b/cidade_integra/lib/utils/badge_rules.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import '../models/app_user.dart';
+
+class Badge {
+  final String id;
+  final String label;
+  final IconData icon;
+  final Color color;
+  final bool Function(AppUser user) condition;
+
+  const Badge({
+    required this.id,
+    required this.label,
+    required this.icon,
+    required this.color,
+    required this.condition,
+  });
+}
+
+final badgeRules = [
+  Badge(
+    id: 'iniciante',
+    label: 'Iniciante',
+    icon: Icons.eco,
+    color: const Color(0xFF2ECC71),
+    condition: (u) => u.score >= 0 && u.score < 100,
+  ),
+  Badge(
+    id: 'engajado',
+    label: 'Engajado',
+    icon: Icons.local_fire_department,
+    color: const Color(0xFFF39C12),
+    condition: (u) => u.score >= 100 && u.score < 500,
+  ),
+  Badge(
+    id: 'vigilante',
+    label: 'Vigilante Urbano',
+    icon: Icons.shield,
+    color: const Color(0xFF3498DB),
+    condition: (u) => u.score >= 500,
+  ),
+  Badge(
+    id: 'reportador_frequente',
+    label: 'Reportador Frequente',
+    icon: Icons.campaign,
+    color: const Color(0xFF9B59B6),
+    condition: (u) => u.reportCount >= 20,
+  ),
+  Badge(
+    id: 'verificado',
+    label: 'Usuário Verificado',
+    icon: Icons.verified,
+    color: const Color(0xFF1ABC9C),
+    condition: (u) => u.verified,
+  ),
+];
+
+List<Badge> getUserBadges(AppUser user) {
+  return badgeRules.where((b) => b.condition(user)).toList();
+}

--- a/cidade_integra/lib/widgets/perfil/badges_display.dart
+++ b/cidade_integra/lib/widgets/perfil/badges_display.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import '../../models/app_user.dart';
+import '../../utils/app_theme.dart';
+import '../../utils/badge_rules.dart' as rules;
+
+class BadgesDisplay extends StatelessWidget {
+  final AppUser user;
+  const BadgesDisplay({super.key, required this.user});
+
+  @override
+  Widget build(BuildContext context) {
+    final earned = rules.getUserBadges(user);
+    final earnedIds = earned.map((b) => b.id).toSet();
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppColors.branco,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.bordas),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.emoji_events_outlined, size: 20, color: AppColors.azul),
+              const SizedBox(width: 8),
+              Text(
+                'Conquistas',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w700,
+                  color: AppColors.azul,
+                ),
+              ),
+              const Spacer(),
+              Text(
+                '${earned.length}/${rules.badgeRules.length}',
+                style: TextStyle(
+                  fontSize: 13,
+                  color: AppColors.textoSecundario,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Wrap(
+            spacing: 10,
+            runSpacing: 10,
+            children: rules.badgeRules.map((badge) {
+              final isEarned = earnedIds.contains(badge.id);
+              return _BadgeChip(badge: badge, earned: isEarned);
+            }).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BadgeChip extends StatelessWidget {
+  final rules.Badge badge;
+  final bool earned;
+
+  const _BadgeChip({required this.badge, required this.earned});
+
+  @override
+  Widget build(BuildContext context) {
+    return Opacity(
+      opacity: earned ? 1.0 : 0.35,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: earned
+              ? badge.color.withValues(alpha: 0.1)
+              : Colors.grey.shade100,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: earned
+                ? badge.color.withValues(alpha: 0.3)
+                : Colors.grey.shade300,
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              badge.icon,
+              size: 16,
+              color: earned ? badge.color : Colors.grey,
+            ),
+            const SizedBox(width: 6),
+            Text(
+              badge.label,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: earned ? badge.color : Colors.grey,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/cidade_integra/lib/widgets/perfil/minhas_denuncias.dart
+++ b/cidade_integra/lib/widgets/perfil/minhas_denuncias.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import '../../models/report.dart';
+import '../../services/report_service.dart';
+import '../../services/saved_reports_service.dart';
+import '../../utils/app_theme.dart';
+import '../denuncias/card_denuncia.dart';
+
+class MinhasDenuncias extends StatefulWidget {
+  final String userId;
+  const MinhasDenuncias({super.key, required this.userId});
+
+  @override
+  State<MinhasDenuncias> createState() => _MinhasDenunciasState();
+}
+
+class _MinhasDenunciasState extends State<MinhasDenuncias>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+    _tabController.addListener(() {
+      if (!_tabController.indexIsChanging) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Container(
+            decoration: BoxDecoration(
+              color: AppColors.branco,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: AppColors.bordas),
+            ),
+            child: Column(
+              children: [
+                TabBar(
+                  controller: _tabController,
+                  labelColor: AppColors.verde,
+                  unselectedLabelColor: AppColors.textoSecundario,
+                  indicatorColor: AppColors.verde,
+                  indicatorWeight: 3,
+                  labelStyle: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                  ),
+                  tabs: const [
+                    Tab(text: 'Minhas Denúncias'),
+                    Tab(text: 'Salvas'),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                _tabController.index == 0
+                    ? _MyReportsList(userId: widget.userId)
+                    : _SavedReportsList(userId: widget.userId),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _MyReportsList extends StatelessWidget {
+  final String userId;
+  const _MyReportsList({required this.userId});
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<Report>>(
+      future: ReportService().getReportsByUser(userId),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Padding(
+            padding: EdgeInsets.all(32),
+            child: Center(child: CircularProgressIndicator()),
+          );
+        }
+
+        final reports = snapshot.data ?? [];
+        if (reports.isEmpty) {
+          return Padding(
+            padding: const EdgeInsets.all(32),
+            child: Center(
+              child: Column(
+                children: [
+                  Icon(Icons.campaign_outlined,
+                      size: 40, color: AppColors.textoSecundario),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Você ainda não fez nenhuma denúncia.',
+                    style: TextStyle(color: AppColors.textoSecundario),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+
+        return Column(
+          children: reports
+              .map((r) => CardDenuncia(
+                    report: r,
+                    onTap: () => context.go('/denuncias/${r.id}'),
+                  ))
+              .toList(),
+        );
+      },
+    );
+  }
+}
+
+class _SavedReportsList extends StatelessWidget {
+  final String userId;
+  const _SavedReportsList({required this.userId});
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<Report>>(
+      future: SavedReportsService().getSavedReports(userId),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Padding(
+            padding: EdgeInsets.all(32),
+            child: Center(child: CircularProgressIndicator()),
+          );
+        }
+
+        final reports = snapshot.data ?? [];
+        if (reports.isEmpty) {
+          return Padding(
+            padding: const EdgeInsets.all(32),
+            child: Center(
+              child: Column(
+                children: [
+                  Icon(Icons.bookmark_outline,
+                      size: 40, color: AppColors.textoSecundario),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Nenhuma denúncia salva.',
+                    style: TextStyle(color: AppColors.textoSecundario),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+
+        return Column(
+          children: reports
+              .map((r) => CardDenuncia(
+                    report: r,
+                    onTap: () => context.go('/denuncias/${r.id}'),
+                  ))
+              .toList(),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
### 🔵 [Integração | 5 pontos] Minhas Denúncias e Denúncias Salvas

#### 🧩 Descrição
Implementar duas seções na tela de perfil: "Minhas Denúncias" (criadas pelo usuário) e "Denúncias Salvas" (favoritadas), com tabs para alternar.

#### 🎯 Objetivo e Critérios de Aceite
- [x] Seção "Minhas Denúncias" exibe lista onde `userId == currentUser.uid`.
- [x] Cada item usa o widget `CardDenuncia`.
- [x] Seção "Denúncias Salvas" lê da subcoleção `users/{uid}/savedReports`.
- [x] `SavedReportsService` com métodos: `saveReport`, `removeReport`, `isSaved`, `getSavedReports`.
- [x] Tabs para alternar entre "Minhas" e "Salvas".
- [x] Estados vazios com mensagem e ícone.
- [x] Integrado na tela de perfil.