### PR TITLE
🔵 [Integração | 5 pontos] Gestão de Usuários (Admin)

### DIFF
--- a/cidade_integra/lib/screens/admin/admin_dashboard_screen.dart
+++ b/cidade_integra/lib/screens/admin/admin_dashboard_screen.dart
@@ -1,12 +1,399 @@
 import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import '../../models/report.dart';
+import '../../services/admin_service.dart';
+import '../../utils/app_theme.dart';
+import '../../widgets/denuncias/status_badge.dart';
 
-class AdminDashboardScreen extends StatelessWidget {
+class AdminDashboardScreen extends StatefulWidget {
   const AdminDashboardScreen({super.key});
 
   @override
+  State<AdminDashboardScreen> createState() => _AdminDashboardScreenState();
+}
+
+class _AdminDashboardScreenState extends State<AdminDashboardScreen> {
+  final _service = AdminService();
+  Map<String, int>? _stats;
+  int _totalUsers = 0;
+  List<Report> _recent = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final results = await Future.wait([
+        _service.getReportStats(),
+        _service.getTotalUsers(),
+        _service.getRecentReports(),
+      ]);
+      if (mounted) {
+        setState(() {
+          _stats = results[0] as Map<String, int>;
+          _totalUsers = results[1] as int;
+          _recent = results[2] as List<Report>;
+          _loading = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text('Admin — Dashboard', style: TextStyle(fontSize: 24)),
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildHeader(),
+        _buildStatCards(),
+        if (_stats != null) _buildChart(),
+        _buildNavCards(),
+        if (_recent.isNotEmpty) _buildRecentList(),
+        const SizedBox(height: 24),
+      ],
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(24),
+      color: AppColors.azul,
+      child: const Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Painel Administrativo',
+            style: TextStyle(
+              fontSize: 24,
+              fontWeight: FontWeight.w800,
+              color: Colors.white,
+            ),
+          ),
+          SizedBox(height: 4),
+          Text(
+            'Visão geral do sistema',
+            style: TextStyle(fontSize: 14, color: Colors.white70),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatCards() {
+    final s = _stats ?? {};
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: GridView.count(
+        crossAxisCount: 2,
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
+        mainAxisSpacing: 12,
+        crossAxisSpacing: 12,
+        childAspectRatio: 1.5,
+        children: [
+          _StatCard(
+            title: 'Total',
+            value: '${s['total'] ?? 0}',
+            icon: Icons.campaign,
+            color: AppColors.azul,
+          ),
+          _StatCard(
+            title: 'Pendentes',
+            value: '${s['pending'] ?? 0}',
+            icon: Icons.hourglass_empty,
+            color: const Color(0xFFF39C12),
+          ),
+          _StatCard(
+            title: 'Em Análise',
+            value: '${s['review'] ?? 0}',
+            icon: Icons.search,
+            color: const Color(0xFF3498DB),
+          ),
+          _StatCard(
+            title: 'Resolvidas',
+            value: '${s['resolved'] ?? 0}',
+            icon: Icons.check_circle,
+            color: const Color(0xFF2ECC71),
+          ),
+          _StatCard(
+            title: 'Rejeitadas',
+            value: '${s['rejected'] ?? 0}',
+            icon: Icons.cancel,
+            color: const Color(0xFFE74C3C),
+          ),
+          _StatCard(
+            title: 'Usuários',
+            value: '$_totalUsers',
+            icon: Icons.people,
+            color: const Color(0xFF9B59B6),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChart() {
+    final s = _stats!;
+    final sections = [
+      _pie('Pendentes', s['pending'] ?? 0, const Color(0xFFF39C12)),
+      _pie('Em Análise', s['review'] ?? 0, const Color(0xFF3498DB)),
+      _pie('Resolvidas', s['resolved'] ?? 0, const Color(0xFF2ECC71)),
+      _pie('Rejeitadas', s['rejected'] ?? 0, const Color(0xFFE74C3C)),
+    ].where((e) => e.value > 0).toList();
+
+    if (sections.isEmpty) return const SizedBox.shrink();
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: AppColors.branco,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: AppColors.bordas),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Distribuição por Status',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                color: AppColors.azul,
+              ),
+            ),
+            const SizedBox(height: 16),
+            SizedBox(
+              height: 180,
+              child: PieChart(
+                PieChartData(
+                  sections: sections,
+                  centerSpaceRadius: 40,
+                  sectionsSpace: 2,
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 16,
+              runSpacing: 6,
+              children: sections
+                  .map((s) => Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Container(
+                            width: 10,
+                            height: 10,
+                            decoration: BoxDecoration(
+                              color: s.color,
+                              shape: BoxShape.circle,
+                            ),
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            s.title,
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: AppColors.textoSecundario,
+                            ),
+                          ),
+                        ],
+                      ))
+                  .toList(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  PieChartSectionData _pie(String label, int value, Color color) {
+    return PieChartSectionData(
+      value: value.toDouble(),
+      color: color,
+      title: '$value',
+      titleStyle: const TextStyle(
+        fontSize: 12,
+        fontWeight: FontWeight.w600,
+        color: Colors.white,
+      ),
+      radius: 35,
+    );
+  }
+
+  Widget _buildNavCards() {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        children: [
+          Expanded(
+            child: _NavCard(
+              icon: Icons.list_alt,
+              label: 'Gestão de\nDenúncias',
+              onTap: () => context.go('/admin/denuncias'),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: _NavCard(
+              icon: Icons.people_outline,
+              label: 'Gestão de\nUsuários',
+              onTap: () => context.go('/admin/usuarios'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRecentList() {
+    final dateFormat = DateFormat('dd/MM/yyyy');
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Container(
+        decoration: BoxDecoration(
+          color: AppColors.branco,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: AppColors.bordas),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text(
+                'Denúncias Recentes',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w700,
+                  color: AppColors.azul,
+                ),
+              ),
+            ),
+            const Divider(height: 1),
+            ...List.generate(_recent.length, (i) {
+              final r = _recent[i];
+              return ListTile(
+                title: Text(
+                  r.title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                    color: AppColors.azul,
+                  ),
+                ),
+                subtitle: Text(
+                  dateFormat.format(r.createdAt),
+                  style: TextStyle(fontSize: 12, color: AppColors.textoSecundario),
+                ),
+                trailing: StatusBadge(status: r.status),
+                onTap: () => context.go('/denuncias/${r.id}'),
+              );
+            }),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatCard extends StatelessWidget {
+  final String title;
+  final String value;
+  final IconData icon;
+  final Color color;
+
+  const _StatCard({
+    required this.title,
+    required this.value,
+    required this.icon,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.15)),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(icon, size: 24, color: color),
+          const SizedBox(height: 6),
+          Text(
+            value,
+            style: TextStyle(
+              fontSize: 22,
+              fontWeight: FontWeight.w800,
+              color: color,
+            ),
+          ),
+          Text(
+            title,
+            style: TextStyle(fontSize: 11, color: AppColors.textoSecundario),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NavCard extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  const _NavCard({required this.icon, required this.label, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: Container(
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: AppColors.branco,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: AppColors.bordas),
+        ),
+        child: Column(
+          children: [
+            Icon(icon, size: 32, color: AppColors.verde),
+            const SizedBox(height: 8),
+            Text(
+              label,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: AppColors.azul,
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/cidade_integra/lib/screens/admin/admin_denuncias_screen.dart
+++ b/cidade_integra/lib/screens/admin/admin_denuncias_screen.dart
@@ -1,12 +1,259 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import '../../models/report.dart';
+import '../../providers/auth_provider.dart';
+import '../../services/admin_service.dart';
+import '../../services/report_service.dart';
+import '../../utils/app_theme.dart';
+import '../../widgets/denuncias/status_badge.dart';
 
-class AdminDenunciasScreen extends StatelessWidget {
+class AdminDenunciasScreen extends StatefulWidget {
   const AdminDenunciasScreen({super.key});
 
   @override
+  State<AdminDenunciasScreen> createState() => _AdminDenunciasScreenState();
+}
+
+class _AdminDenunciasScreenState extends State<AdminDenunciasScreen> {
+  final _reportService = ReportService();
+  final _adminService = AdminService();
+  final _searchController = TextEditingController();
+
+  List<Report> _allReports = [];
+  bool _loading = true;
+  String _searchQuery = '';
+  String? _statusFilter;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    try {
+      final reports = await _reportService.getReports();
+      if (mounted) setState(() { _allReports = reports; _loading = false; });
+    } catch (_) {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  List<Report> get _filtered {
+    var list = _allReports;
+    if (_statusFilter != null) {
+      list = list.where((r) => r.status.name == _statusFilter).toList();
+    }
+    if (_searchQuery.isNotEmpty) {
+      final q = _searchQuery.toLowerCase();
+      list = list.where((r) => r.title.toLowerCase().contains(q)).toList();
+    }
+    return list;
+  }
+
+  void _showChangeStatusDialog(Report report) {
+    final commentController = TextEditingController();
+    String? selectedStatus;
+
+    showDialog(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setDialogState) => AlertDialog(
+          title: const Text('Alterar Status'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                report.title,
+                style: TextStyle(
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.azul,
+                ),
+              ),
+              const SizedBox(height: 16),
+              DropdownButtonFormField<String>(
+                decoration: const InputDecoration(labelText: 'Novo Status'),
+                items: ReportStatus.values
+                    .map((s) => DropdownMenuItem(
+                          value: s.name,
+                          child: Text(s.label),
+                        ))
+                    .toList(),
+                onChanged: (v) => setDialogState(() => selectedStatus = v),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: commentController,
+                maxLines: 3,
+                decoration: const InputDecoration(
+                  labelText: 'Comentário *',
+                  hintText: 'Motivo da alteração...',
+                ),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text('Cancelar'),
+            ),
+            ElevatedButton(
+              onPressed: selectedStatus != null &&
+                      commentController.text.trim().isNotEmpty
+                  ? () async {
+                      Navigator.pop(ctx);
+                      final auth = context.read<AuthProvider>();
+                      await _adminService.updateReportStatusWithAudit(
+                        reportId: report.id,
+                        newStatus: selectedStatus!,
+                        comment: commentController.text.trim(),
+                        userId: auth.user!.uid,
+                        userName: auth.user!.displayName ?? 'Admin',
+                      );
+                      if (mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('Status atualizado.')),
+                        );
+                        _load();
+                      }
+                    }
+                  : null,
+              child: const Text('Confirmar'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text('Admin — Denúncias', style: TextStyle(fontSize: 24)),
+    final dateFormat = DateFormat('dd/MM/yy');
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(24),
+          color: AppColors.azul,
+          child: const Text(
+            'Gestão de Denúncias',
+            style: TextStyle(
+              fontSize: 22,
+              fontWeight: FontWeight.w800,
+              color: Colors.white,
+            ),
+          ),
+        ),
+
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          child: TextField(
+            controller: _searchController,
+            onChanged: (v) => setState(() => _searchQuery = v),
+            decoration: InputDecoration(
+              hintText: 'Buscar por título...',
+              prefixIcon: const Icon(Icons.search),
+              suffixIcon: _searchQuery.isNotEmpty
+                  ? IconButton(
+                      icon: const Icon(Icons.clear),
+                      onPressed: () {
+                        _searchController.clear();
+                        setState(() => _searchQuery = '');
+                      },
+                    )
+                  : null,
+            ),
+          ),
+        ),
+
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: [
+                FilterChip(
+                  label: const Text('Todas'),
+                  selected: _statusFilter == null,
+                  onSelected: (_) => setState(() => _statusFilter = null),
+                  selectedColor: AppColors.verde.withValues(alpha: 0.15),
+                ),
+                const SizedBox(width: 6),
+                for (final s in ReportStatus.values) ...[
+                  FilterChip(
+                    label: Text(s.label),
+                    selected: _statusFilter == s.name,
+                    onSelected: (_) =>
+                        setState(() => _statusFilter = s.name),
+                    selectedColor: s.color.withValues(alpha: 0.15),
+                  ),
+                  const SizedBox(width: 6),
+                ],
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 8),
+
+        if (_loading)
+          const Padding(
+            padding: EdgeInsets.all(32),
+            child: Center(child: CircularProgressIndicator()),
+          )
+        else if (_filtered.isEmpty)
+          Padding(
+            padding: const EdgeInsets.all(32),
+            child: Center(
+              child: Text(
+                'Nenhuma denúncia encontrada.',
+                style: TextStyle(color: AppColors.textoSecundario),
+              ),
+            ),
+          )
+        else
+          ...List.generate(_filtered.length, (i) {
+            final r = _filtered[i];
+            return ListTile(
+              title: Text(
+                r.title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w500,
+                  color: AppColors.azul,
+                ),
+              ),
+              subtitle: Text(
+                '${r.category.label} · ${dateFormat.format(r.createdAt)}',
+                style: TextStyle(fontSize: 12, color: AppColors.textoSecundario),
+              ),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  StatusBadge(status: r.status),
+                  const SizedBox(width: 4),
+                  IconButton(
+                    icon: const Icon(Icons.edit_outlined, size: 20),
+                    tooltip: 'Alterar Status',
+                    onPressed: () => _showChangeStatusDialog(r),
+                  ),
+                ],
+              ),
+            );
+          }),
+      ],
     );
   }
 }

--- a/cidade_integra/lib/screens/admin/admin_usuarios_screen.dart
+++ b/cidade_integra/lib/screens/admin/admin_usuarios_screen.dart
@@ -1,12 +1,330 @@
 import 'package:flutter/material.dart';
+import '../../models/app_user.dart';
+import '../../services/admin_service.dart';
+import '../../utils/app_theme.dart';
 
-class AdminUsuariosScreen extends StatelessWidget {
+class AdminUsuariosScreen extends StatefulWidget {
   const AdminUsuariosScreen({super.key});
 
   @override
+  State<AdminUsuariosScreen> createState() => _AdminUsuariosScreenState();
+}
+
+class _AdminUsuariosScreenState extends State<AdminUsuariosScreen> {
+  final _service = AdminService();
+  final _searchController = TextEditingController();
+
+  List<AppUser> _allUsers = [];
+  bool _loading = true;
+  String _searchQuery = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    try {
+      final users = await _service.getAllUsers();
+      if (mounted) setState(() { _allUsers = users; _loading = false; });
+    } catch (_) {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  List<AppUser> get _filtered {
+    if (_searchQuery.isEmpty) return _allUsers;
+    final q = _searchQuery.toLowerCase();
+    return _allUsers.where((u) =>
+        u.displayName.toLowerCase().contains(q) ||
+        u.email.toLowerCase().contains(q)).toList();
+  }
+
+  void _confirmRoleChange(AppUser user) {
+    final newRole = user.role == 'admin' ? 'user' : 'admin';
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Alterar Permissão'),
+        content: Text(
+          'Alterar "${user.displayName}" de '
+          '${user.role == "admin" ? "Admin" : "Usuário"} '
+          'para ${newRole == "admin" ? "Admin" : "Usuário"}?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancelar'),
+          ),
+          ElevatedButton(
+            onPressed: () async {
+              Navigator.pop(ctx);
+              await _service.updateUserRole(user.uid, newRole);
+              if (mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text('Permissão alterada para $newRole.')),
+                );
+                _load();
+              }
+            },
+            child: const Text('Confirmar'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _confirmStatusChange(AppUser user) {
+    final newStatus = user.status == 'active' ? 'inactive' : 'active';
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(newStatus == 'inactive' ? 'Desativar Usuário' : 'Reativar Usuário'),
+        content: Text(
+          '${newStatus == "inactive" ? "Desativar" : "Reativar"} '
+          'a conta de "${user.displayName}"?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancelar'),
+          ),
+          ElevatedButton(
+            onPressed: () async {
+              Navigator.pop(ctx);
+              await _service.updateUserStatus(user.uid, newStatus);
+              if (mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text(newStatus == 'inactive'
+                        ? 'Usuário desativado.'
+                        : 'Usuário reativado.'),
+                  ),
+                );
+                _load();
+              }
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: newStatus == 'inactive'
+                  ? AppColors.vermelho
+                  : AppColors.verde,
+            ),
+            child: Text(newStatus == 'inactive' ? 'Desativar' : 'Reativar'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text('Admin — Usuários', style: TextStyle(fontSize: 24)),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(24),
+          color: AppColors.azul,
+          child: Row(
+            children: [
+              const Expanded(
+                child: Text(
+                  'Gestão de Usuários',
+                  style: TextStyle(
+                    fontSize: 22,
+                    fontWeight: FontWeight.w800,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                decoration: BoxDecoration(
+                  color: Colors.white.withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Text(
+                  '${_allUsers.length} usuários',
+                  style: const TextStyle(fontSize: 13, color: Colors.white),
+                ),
+              ),
+            ],
+          ),
+        ),
+
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: TextField(
+            controller: _searchController,
+            onChanged: (v) => setState(() => _searchQuery = v),
+            decoration: InputDecoration(
+              hintText: 'Buscar por nome ou email...',
+              prefixIcon: const Icon(Icons.search),
+              suffixIcon: _searchQuery.isNotEmpty
+                  ? IconButton(
+                      icon: const Icon(Icons.clear),
+                      onPressed: () {
+                        _searchController.clear();
+                        setState(() => _searchQuery = '');
+                      },
+                    )
+                  : null,
+            ),
+          ),
+        ),
+
+        if (_loading)
+          const Padding(
+            padding: EdgeInsets.all(32),
+            child: Center(child: CircularProgressIndicator()),
+          )
+        else if (_filtered.isEmpty)
+          Padding(
+            padding: const EdgeInsets.all(32),
+            child: Center(
+              child: Text(
+                'Nenhum usuário encontrado.',
+                style: TextStyle(color: AppColors.textoSecundario),
+              ),
+            ),
+          )
+        else
+          ...List.generate(_filtered.length, (i) {
+            final u = _filtered[i];
+            return _UserTile(
+              user: u,
+              onRoleChange: () => _confirmRoleChange(u),
+              onStatusChange: () => _confirmStatusChange(u),
+            );
+          }),
+      ],
+    );
+  }
+}
+
+class _UserTile extends StatelessWidget {
+  final AppUser user;
+  final VoidCallback onRoleChange;
+  final VoidCallback onStatusChange;
+
+  const _UserTile({
+    required this.user,
+    required this.onRoleChange,
+    required this.onStatusChange,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isActive = user.status == 'active';
+
+    return Opacity(
+      opacity: isActive ? 1.0 : 0.5,
+      child: ListTile(
+        leading: CircleAvatar(
+          backgroundColor: user.isAdmin ? AppColors.verde : AppColors.azul,
+          child: Text(
+            user.displayName.isNotEmpty
+                ? user.displayName[0].toUpperCase()
+                : '?',
+            style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w600),
+          ),
+        ),
+        title: Row(
+          children: [
+            Flexible(
+              child: Text(
+                user.displayName,
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w500,
+                  color: AppColors.azul,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            const SizedBox(width: 6),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: user.isAdmin
+                    ? AppColors.verde.withValues(alpha: 0.15)
+                    : AppColors.azul.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Text(
+                user.isAdmin ? 'Admin' : 'Usuário',
+                style: TextStyle(
+                  fontSize: 10,
+                  fontWeight: FontWeight.w600,
+                  color: user.isAdmin ? AppColors.verde : AppColors.azul,
+                ),
+              ),
+            ),
+            if (!isActive) ...[
+              const SizedBox(width: 4),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: AppColors.vermelho.withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  'Inativo',
+                  style: TextStyle(
+                    fontSize: 10,
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.vermelho,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+        subtitle: Text(
+          '${user.email} · Score: ${user.score}',
+          style: TextStyle(fontSize: 12, color: AppColors.textoSecundario),
+          overflow: TextOverflow.ellipsis,
+        ),
+        trailing: PopupMenuButton<String>(
+          onSelected: (action) {
+            if (action == 'role') onRoleChange();
+            if (action == 'status') onStatusChange();
+          },
+          itemBuilder: (_) => [
+            PopupMenuItem(
+              value: 'role',
+              child: Row(
+                children: [
+                  const Icon(Icons.swap_horiz, size: 18),
+                  const SizedBox(width: 8),
+                  Text(user.isAdmin ? 'Tornar Usuário' : 'Tornar Admin'),
+                ],
+              ),
+            ),
+            PopupMenuItem(
+              value: 'status',
+              child: Row(
+                children: [
+                  Icon(
+                    isActive ? Icons.block : Icons.check_circle_outline,
+                    size: 18,
+                  ),
+                  const SizedBox(width: 8),
+                  Text(isActive ? 'Desativar' : 'Reativar'),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/cidade_integra/lib/services/admin_service.dart
+++ b/cidade_integra/lib/services/admin_service.dart
@@ -1,0 +1,76 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/app_user.dart';
+import '../models/report.dart';
+
+class AdminService {
+  final _reports = FirebaseFirestore.instance.collection('reports');
+  final _users = FirebaseFirestore.instance.collection('users');
+
+  Future<Map<String, int>> getReportStats() async {
+    final snapshot = await _reports.get();
+    final stats = {'total': 0, 'pending': 0, 'review': 0, 'resolved': 0, 'rejected': 0};
+
+    for (final doc in snapshot.docs) {
+      stats['total'] = (stats['total'] ?? 0) + 1;
+      final status = doc.data()['status'] as String? ?? 'pending';
+      stats[status] = (stats[status] ?? 0) + 1;
+    }
+    return stats;
+  }
+
+  Future<int> getTotalUsers() async {
+    final snapshot = await _users.count().get();
+    return snapshot.count ?? 0;
+  }
+
+  Future<List<Report>> getRecentReports({int limit = 5}) async {
+    final snapshot = await _reports
+        .orderBy('createdAt', descending: true)
+        .limit(limit)
+        .get();
+    return snapshot.docs.map((doc) => Report.fromFirestore(doc)).toList();
+  }
+
+  Future<List<AppUser>> getAllUsers() async {
+    final snapshot = await _users.orderBy('createdAt', descending: true).get();
+    return snapshot.docs.map((doc) => AppUser.fromFirestore(doc)).toList();
+  }
+
+  Future<void> updateUserRole(String uid, String newRole) async {
+    await _users.doc(uid).update({'role': newRole});
+  }
+
+  Future<void> updateUserStatus(String uid, String newStatus) async {
+    await _users.doc(uid).update({'status': newStatus});
+  }
+
+  Future<void> updateReportStatusWithAudit({
+    required String reportId,
+    required String newStatus,
+    required String comment,
+    required String userId,
+    required String userName,
+  }) async {
+    final batch = FirebaseFirestore.instance.batch();
+
+    final reportRef = _reports.doc(reportId);
+    batch.update(reportRef, {
+      'status': newStatus,
+      'updatedAt': FieldValue.serverTimestamp(),
+      if (newStatus == 'resolved') 'resolvedAt': FieldValue.serverTimestamp(),
+    });
+
+    final auditRef = FirebaseFirestore.instance.collection('auditlogs').doc();
+    batch.set(auditRef, {
+      'timestamp': FieldValue.serverTimestamp(),
+      'userId': userId,
+      'userDisplayName': userName,
+      'reportId': reportId,
+      'action': 'status_change',
+      'newStatus': newStatus,
+      'comment': comment,
+    });
+
+    await batch.commit();
+  }
+}

--- a/cidade_integra/pubspec.yaml
+++ b/cidade_integra/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   uuid: ^4.5.3
   flutter_map: ^8.3.0
   latlong2: ^0.9.1
+  fl_chart: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### 🔵 [Integração | 5 pontos] Gestão de Usuários (Admin)

#### 🧩 Descrição
Tela de gestão de usuários para administradores com busca, alteração de role e status.

#### 🎯 Objetivo e Critérios de Aceite
- [x] Tela `lib/screens/admin/admin_usuarios_screen.dart` criada.
- [x] Lista de usuários com: nome, email, role, status, score.
- [x] Campo de busca por nome ou email.
- [x] `PopupMenuButton` com ações: alterar role (user ↔ admin), alterar status (ativar/desativar).
- [x] Diálogo de confirmação para cada ação.
- [x] Indicadores visuais: badge de role (Admin/Usuário), badge "Inativo", opacidade reduzida para inativos.
- [x] Avatar com inicial do nome e cor diferenciada por role.