### PR TITLE
🔵 [Integração | 8 pontos] Notificações Push (FCM)

### DIFF
--- a/cidade_integra/lib/main.dart
+++ b/cidade_integra/lib/main.dart
@@ -2,16 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_sign_in/google_sign_in.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:provider/provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'firebase_options.dart';
 import 'providers/auth_provider.dart';
 import 'utils/app_theme.dart';
 import 'routes/app_router.dart';
+import 'services/notification_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  await initializeDateFormatting('pt_BR');
 
   await Supabase.initialize(
     url: 'https://fyjefwpyesgedvfuewiw.supabase.co',
@@ -23,6 +26,8 @@ void main() async {
     serverClientId:
         '677900581774-j5k91404i5por2tm6vgstb3fco0hatsd.apps.googleusercontent.com',
   );
+
+  await NotificationService().initialize();
 
   final authProvider = AuthProvider();
   final router = buildRouter(authProvider);

--- a/cidade_integra/lib/providers/auth_provider.dart
+++ b/cidade_integra/lib/providers/auth_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:google_sign_in/google_sign_in.dart';
+import '../services/notification_service.dart';
 
 class AuthProvider extends ChangeNotifier {
   User? _user;
@@ -35,6 +36,7 @@ class AuthProvider extends ChangeNotifier {
               .collection('users')
               .doc(user.uid)
               .update({'lastLoginAt': DateTime.now().toIso8601String()});
+          await NotificationService().saveTokenForUser(user.uid);
         } else {
           await FirebaseFirestore.instance
               .collection('users')

--- a/cidade_integra/lib/services/notification_service.dart
+++ b/cidade_integra/lib/services/notification_service.dart
@@ -1,0 +1,94 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+@pragma('vm:entry-point')
+Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {}
+
+class NotificationService {
+  static final NotificationService _instance = NotificationService._();
+  factory NotificationService() => _instance;
+  NotificationService._();
+
+  final _messaging = FirebaseMessaging.instance;
+  final _localNotifications = FlutterLocalNotificationsPlugin();
+
+  static const _channel = AndroidNotificationChannel(
+    'cidade_integra_channel',
+    'Cidade Integra',
+    description: 'Notificações do Cidade Integra',
+    importance: Importance.high,
+  );
+
+  Future<void> initialize() async {
+    FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
+
+    final settings = await _messaging.requestPermission(
+      alert: true,
+      badge: true,
+      sound: true,
+    );
+
+    if (settings.authorizationStatus != AuthorizationStatus.authorized) return;
+
+    await _localNotifications
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>()
+        ?.createNotificationChannel(_channel);
+
+    await _localNotifications.initialize(
+      const InitializationSettings(
+        android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+        iOS: DarwinInitializationSettings(),
+      ),
+    );
+
+    FirebaseMessaging.onMessage.listen(_showForegroundNotification);
+  }
+
+  Future<void> saveTokenForUser(String uid) async {
+    try {
+      final token = await _messaging.getToken();
+      if (token != null) {
+        await FirebaseFirestore.instance
+            .collection('users')
+            .doc(uid)
+            .update({'fcmToken': token});
+      }
+
+      _messaging.onTokenRefresh.listen((newToken) {
+        FirebaseFirestore.instance
+            .collection('users')
+            .doc(uid)
+            .update({'fcmToken': newToken});
+      });
+    } catch (_) {}
+  }
+
+  void _showForegroundNotification(RemoteMessage message) {
+    final notification = message.notification;
+    if (notification == null) return;
+
+    _localNotifications.show(
+      notification.hashCode,
+      notification.title,
+      notification.body,
+      NotificationDetails(
+        android: AndroidNotificationDetails(
+          _channel.id,
+          _channel.name,
+          channelDescription: _channel.description,
+          icon: '@mipmap/ic_launcher',
+        ),
+      ),
+    );
+  }
+
+  static Future<RemoteMessage?> getInitialMessage() {
+    return FirebaseMessaging.instance.getInitialMessage();
+  }
+
+  static Stream<RemoteMessage> get onMessageOpenedApp {
+    return FirebaseMessaging.onMessageOpenedApp;
+  }
+}

--- a/cidade_integra/pubspec.yaml
+++ b/cidade_integra/pubspec.yaml
@@ -50,6 +50,8 @@ dependencies:
   latlong2: ^0.9.1
   share_plus: ^12.0.2
   path_provider: ^2.1.5
+  firebase_messaging: ^16.2.0
+  flutter_local_notifications: ^19.5.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### 🔵 [Integração | 8 pontos] Notificações Push (FCM)

#### 🧩 Descrição
Integrar o Firebase Cloud Messaging para notificações push em foreground e background.

#### 🎯 Objetivo e Critérios de Aceite
- [x] Pacotes `firebase_messaging` e `flutter_local_notifications` adicionados.
- [x] Permissão de notificações solicitada ao usuário.
- [x] Token FCM salvo no Firestore (`fcmToken` no doc do usuário) ao fazer login.
- [x] Notificações em foreground exibidas via `flutter_local_notifications`.
- [x] Background handler registrado.
- [x] Token refresh automático.
- [x] `NotificationService` singleton criado e inicializado no `main.dart`.