### PR TITLE
🔧 Batch: secure storage, Firestore rules, testes, App Check

### DIFF
--- a/cidade_integra/firestore.rules
+++ b/cidade_integra/firestore.rules
@@ -1,0 +1,94 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    function isAuth() {
+      return request.auth != null;
+    }
+
+    function isOwner(uid) {
+      return isAuth() && request.auth.uid == uid;
+    }
+
+    function isAdmin() {
+      return isAuth() &&
+        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "admin";
+    }
+
+    function isOwnerOrAdmin(uid) {
+      return isOwner(uid) || isAdmin();
+    }
+
+    // ── reports ──────────────────────────────────────────────
+    match /reports/{reportId} {
+      allow read: if true;
+
+      allow create: if isAuth()
+        && request.resource.data.title is string
+        && request.resource.data.title.size() >= 3
+        && request.resource.data.title.size() <= 100
+        && request.resource.data.description is string
+        && request.resource.data.description.size() >= 10
+        && request.resource.data.description.size() <= 2000
+        && request.resource.data.category in [
+             'buracos','iluminacao','lixo','vazamentos','areasVerdes','outros'
+           ]
+        && request.resource.data.status == 'pending';
+
+      allow update: if isAuth() && (
+        request.auth.uid == resource.data.userId || isAdmin()
+      );
+
+      allow delete: if isAdmin();
+
+      // ── comments ────────────────────────────────────────────
+      match /comments/{commentId} {
+        allow read: if true;
+
+        allow create: if isAuth()
+          && request.resource.data.message is string
+          && request.resource.data.message.size() >= 5
+          && request.resource.data.message.size() <= 500
+          && request.resource.data.authorId == request.auth.uid;
+
+        allow update, delete: if isAuth() && (
+          request.auth.uid == resource.data.authorId || isAdmin()
+        );
+      }
+    }
+
+    // ── users ────────────────────────────────────────────────
+    match /users/{userId} {
+      allow read: if true;
+
+      allow create: if isOwner(userId);
+
+      allow update: if isOwner(userId) || isAdmin();
+
+      allow delete: if false;
+
+      // ── denúncias salvas ──────────────────────────────────
+      match /denunciasSalvas/{denunciaId} {
+        allow read, write: if isOwner(userId);
+      }
+    }
+
+    // ── audit logs ───────────────────────────────────────────
+    match /auditLogs/{logId} {
+      allow create: if isAuth();
+      allow read: if isAdmin();
+      allow update, delete: if false;
+    }
+
+    // ── FAQ ──────────────────────────────────────────────────
+    match /faq_categories/{categoryId} {
+      allow read: if true;
+      allow write: if isAdmin();
+
+      match /items/{itemId} {
+        allow read: if true;
+        allow write: if isAdmin();
+      }
+    }
+  }
+}

--- a/cidade_integra/lib/main.dart
+++ b/cidade_integra/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_sign_in/google_sign_in.dart';
@@ -20,6 +21,11 @@ void main() async {
   Env.assertConfigured();
 
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+
+  await FirebaseAppCheck.instance.activate(
+    androidProvider: AndroidProvider.playIntegrity,
+    appleProvider: AppleProvider.appAttest,
+  );
 
   FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
   PlatformDispatcher.instance.onError = (error, stack) {

--- a/cidade_integra/lib/providers/auth_provider.dart
+++ b/cidade_integra/lib/providers/auth_provider.dart
@@ -4,6 +4,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import '../services/notification_service.dart';
+import '../services/secure_storage_service.dart';
 
 class AuthProvider extends ChangeNotifier {
   User? _user;
@@ -71,6 +72,7 @@ class AuthProvider extends ChangeNotifier {
     try {
       await GoogleSignIn.instance.signOut();
     } catch (_) {}
+    await SecureStorageService.clearAll();
     await FirebaseAuth.instance.signOut();
   }
 

--- a/cidade_integra/lib/services/notification_service.dart
+++ b/cidade_integra/lib/services/notification_service.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'secure_storage_service.dart';
 
 @pragma('vm:entry-point')
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {}
@@ -50,6 +51,7 @@ class NotificationService {
     try {
       final token = await _messaging.getToken();
       if (token != null) {
+        await SecureStorageService.saveFcmToken(token);
         await FirebaseFirestore.instance
             .collection('users')
             .doc(uid)
@@ -57,6 +59,7 @@ class NotificationService {
       }
 
       _messaging.onTokenRefresh.listen((newToken) {
+        SecureStorageService.saveFcmToken(newToken);
         FirebaseFirestore.instance
             .collection('users')
             .doc(uid)

--- a/cidade_integra/lib/services/secure_storage_service.dart
+++ b/cidade_integra/lib/services/secure_storage_service.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class SecureStorageService {
+  static const _storage = FlutterSecureStorage(
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+  );
+
+  static const _fcmTokenKey = 'fcm_token';
+  static const _lastUidKey = 'last_uid';
+
+  static Future<void> saveFcmToken(String token) async {
+    await _storage.write(key: _fcmTokenKey, value: token);
+  }
+
+  static Future<String?> readFcmToken() async {
+    return _storage.read(key: _fcmTokenKey);
+  }
+
+  static Future<void> saveLastUid(String uid) async {
+    await _storage.write(key: _lastUidKey, value: uid);
+  }
+
+  static Future<String?> readLastUid() async {
+    return _storage.read(key: _lastUidKey);
+  }
+
+  static Future<void> clearAll() async {
+    await _storage.deleteAll();
+  }
+}

--- a/cidade_integra/pubspec.yaml
+++ b/cidade_integra/pubspec.yaml
@@ -54,6 +54,8 @@ dependencies:
   flutter_local_notifications: ^19.5.0
   firebase_analytics: ^12.3.0
   firebase_crashlytics: ^5.2.0
+  flutter_secure_storage: ^10.2.0
+  firebase_app_check: ^0.4.4+1
 
 dev_dependencies:
   flutter_test:

--- a/cidade_integra/test/models/app_user_test.dart
+++ b/cidade_integra/test/models/app_user_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cidade_integra/models/app_user.dart';
+
+void main() {
+  final baseUser = AppUser(
+    uid: 'test-uid',
+    displayName: 'Test User',
+    email: 'test@test.com',
+    createdAt: '2025-01-01',
+    lastLoginAt: '2025-06-01',
+    role: 'user',
+    score: 50,
+    reportCount: 3,
+  );
+
+  group('AppUser', () {
+    test('isAdmin returns false for regular user', () {
+      expect(baseUser.isAdmin, isFalse);
+    });
+
+    test('isAdmin returns true for admin role', () {
+      final admin = baseUser.copyWith(displayName: 'Admin');
+      final adminUser = AppUser(
+        uid: 'admin-uid',
+        displayName: 'Admin',
+        email: 'admin@test.com',
+        createdAt: '2025-01-01',
+        lastLoginAt: '2025-01-01',
+        role: 'admin',
+      );
+      expect(adminUser.isAdmin, isTrue);
+      expect(admin.isAdmin, isFalse);
+    });
+
+    test('copyWith preserves unchanged fields', () {
+      final updated = baseUser.copyWith(bio: 'Hello');
+      expect(updated.uid, baseUser.uid);
+      expect(updated.email, baseUser.email);
+      expect(updated.displayName, baseUser.displayName);
+      expect(updated.bio, 'Hello');
+    });
+
+    test('copyWith overrides specified fields', () {
+      final updated = baseUser.copyWith(
+        displayName: 'New Name',
+        score: 100,
+        region: 'SP',
+      );
+      expect(updated.displayName, 'New Name');
+      expect(updated.score, 100);
+      expect(updated.region, 'SP');
+    });
+  });
+}

--- a/cidade_integra/test/utils/input_sanitizer_test.dart
+++ b/cidade_integra/test/utils/input_sanitizer_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cidade_integra/utils/input_sanitizer.dart';
+
+void main() {
+  group('InputSanitizer.sanitize', () {
+    test('removes HTML tags', () {
+      expect(InputSanitizer.sanitize('<b>bold</b>'), 'bold');
+      expect(InputSanitizer.sanitize('<script>alert(1)</script>'), 'alert(1)');
+    });
+
+    test('removes script patterns', () {
+      expect(InputSanitizer.sanitize('onclick=steal()'), 'steal()');
+      expect(InputSanitizer.sanitize('javascript:alert(1)'), 'alert(1)');
+    });
+
+    test('normalizes whitespace', () {
+      expect(InputSanitizer.sanitize('  hello   world  '), 'hello world');
+    });
+
+    test('removes control characters', () {
+      expect(InputSanitizer.sanitize('hello\x00world'), 'helloworld');
+    });
+  });
+
+  group('InputSanitizer.isValidEmail', () {
+    test('accepts valid emails', () {
+      expect(InputSanitizer.isValidEmail('user@example.com'), isTrue);
+      expect(InputSanitizer.isValidEmail('a.b+c@test.co.uk'), isTrue);
+    });
+
+    test('rejects invalid emails', () {
+      expect(InputSanitizer.isValidEmail(''), isFalse);
+      expect(InputSanitizer.isValidEmail('user@'), isFalse);
+      expect(InputSanitizer.isValidEmail('@domain.com'), isFalse);
+      expect(InputSanitizer.isValidEmail('no-at-sign'), isFalse);
+    });
+  });
+
+  group('InputSanitizer.isValidCep', () {
+    test('accepts valid CEPs', () {
+      expect(InputSanitizer.isValidCep('14500-000'), isTrue);
+      expect(InputSanitizer.isValidCep('14500000'), isTrue);
+    });
+
+    test('rejects invalid CEPs', () {
+      expect(InputSanitizer.isValidCep('123'), isFalse);
+      expect(InputSanitizer.isValidCep('abcde-fgh'), isFalse);
+    });
+  });
+
+  group('InputSanitizer.containsBlockedWords', () {
+    test('detects blocked words', () {
+      expect(InputSanitizer.containsBlockedWords('seu idiota'), isTrue);
+    });
+
+    test('passes clean text', () {
+      expect(InputSanitizer.containsBlockedWords('boa tarde'), isFalse);
+    });
+  });
+
+  group('InputSanitizer.validateImageUrl', () {
+    test('allows Supabase URLs', () {
+      const url = 'https://fyjefwpyesgedvfuewiw.supabase.co/storage/v1/object/public/reports/img.jpg';
+      expect(InputSanitizer.validateImageUrl(url), url);
+    });
+
+    test('rejects unknown hosts', () {
+      expect(InputSanitizer.validateImageUrl('https://evil.com/img.jpg'), isNull);
+    });
+
+    test('rejects malformed URLs', () {
+      expect(InputSanitizer.validateImageUrl('not-a-url'), isNull);
+    });
+  });
+
+  group('InputSanitizer.validateEmail', () {
+    test('returns error for empty', () {
+      expect(InputSanitizer.validateEmail(''), isNotNull);
+      expect(InputSanitizer.validateEmail(null), isNotNull);
+    });
+
+    test('returns null for valid', () {
+      expect(InputSanitizer.validateEmail('user@test.com'), isNull);
+    });
+  });
+
+  group('InputSanitizer.validateName', () {
+    test('rejects short names', () {
+      expect(InputSanitizer.validateName('AB'), isNotNull);
+    });
+
+    test('rejects names with numbers', () {
+      expect(InputSanitizer.validateName('User123'), isNotNull);
+    });
+
+    test('accepts valid names', () {
+      expect(InputSanitizer.validateName('Rafael Romano'), isNull);
+      expect(InputSanitizer.validateName('José María'), isNull);
+    });
+  });
+
+  group('InputSanitizer.validateText', () {
+    test('enforces min length', () {
+      expect(
+        InputSanitizer.validateText('ab', fieldName: 'campo', min: 3),
+        isNotNull,
+      );
+    });
+
+    test('detects blocked words when enabled', () {
+      expect(
+        InputSanitizer.validateText('seu idiota', fieldName: 'campo', checkBlocked: true),
+        contains('inadequadas'),
+      );
+    });
+
+    test('passes clean text', () {
+      expect(
+        InputSanitizer.validateText('texto válido', fieldName: 'campo', min: 3),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #92, closes #82, closes #96, closes #86

### Issues resolvidas

| Issue | Pts | O que foi feito |
|-------|-----|-----------------|
| #92 | 3 | `SecureStorageService` com `flutter_secure_storage` — FCM token salvo encrypted, limpa no logout |
| #82 | 5 | `firestore.rules` versionado com validação server-side: types, sizes, category enum, authorId match |
| #96 | 5 | 25 novos testes: `InputSanitizer` (21 testes) + `AppUser` (4 testes). Total: **48 testes passando** |
| #86 | 5 | Firebase App Check ativado com `AndroidProvider.playIntegrity` e `AppleProvider.appAttest` |